### PR TITLE
docs: address markdown lint errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 MD033 -->
+
 # sidero
 
 Sidero ("Iron" in Greek) is a project created by the [Talos Systems](https://www.talos-systems.com/) team.
@@ -36,9 +38,12 @@ At a high level view, the management plane + created clusters should look someth
 
 The Metal Controller Manager provides a few custom resources (CRDs) in the management plane Kubernetes cluster that are crucial to understanding the flow of Sidero:
 
-- **Environments**: These define a desired deployment environment for Talos. This includes things like which kernel to use, kernel args to pass, and the initrd to use.
-- **Servers**: These represent physical machines as resources in the management plane. These servers are created when the physical machine PXE boots and completes a "discovery" process in which it registers with the management plane and provides SMBIOS information.
-- **ServerClasses**: ServerClasses are a grouping of the Servers mentioned above. These can be used to compose a bank of Servers that are eligible for provisioning.
+- **Environments**: These define a desired deployment environment for Talos.
+  This includes things like which kernel to use, kernel args to pass, and the initrd to use.
+- **Servers**: These represent physical machines as resources in the management plane.
+  These servers are created when the physical machine PXE boots and completes a "discovery" process in which it registers with the management plane and provides SMBIOS information.
+- **ServerClasses**: ServerClasses are a grouping of the Servers mentioned above.
+  These can be used to compose a bank of Servers that are eligible for provisioning.
 
 ## Installation
 


### PR DESCRIPTION
This fixes some lint errors, and allows long lines and inline HTML.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
