### PR TITLE
chore: add move label to metal controller manager CRDs

### DIFF
--- a/internal/app/metal-controller-manager/config/crd/kustomization.yaml
+++ b/internal/app/metal-controller-manager/config/crd/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
 - bases/metal.sidero.dev_serverclasses.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
+commonLabels:
+  clusterctl.cluster.x-k8s.io/move: ""
+
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD


### PR DESCRIPTION
This PR goes ahead and adds the proper label that we'll need for our
server, serverclass, and environment CRDs in order for us to pivot them
to a target cluster using `clusterctl move`.