### PR TITLE
fix: ensure servers only get picked once

### DIFF
--- a/docs/website/content/docs/bootstrapping.md
+++ b/docs/website/content/docs/bootstrapping.md
@@ -55,7 +55,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/download/latest/vmlinuz"
+    url: "https://github.com/talos-systems/talos/releases/latest/download/vmlinuz"
     sha512: ""
     args:
       - initrd=initramfs.xz
@@ -75,7 +75,7 @@ spec:
       - talos.platform=metal
       - talos.config=http://$PUBLIC_IP:9091/configdata?uuid=
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/download/latest/initramfs.xz"
+    url: "https://github.com/talos-systems/talos/releases/latest/download/initramfs.xz"
     sha512: ""
 EOF
 ```

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -87,7 +87,6 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: MetalMachineTemplate
         name: ${CLUSTER_NAME}-workers
-        version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: MetalMachineTemplate


### PR DESCRIPTION
This PR adds an additional check to make sure the server we're picking
for a metalmachine isn't already in use. It also moves to using patches
for updating the in-use field. There's also a small doc update and a fix
to the cluster-template that was incorrect.

Will close #28 