### PR TITLE
fix: revert "update namespace to caps-system"

### DIFF
--- a/app/cluster-api-provider-sidero/config/default/kustomization.yaml
+++ b/app/cluster-api-provider-sidero/config/default/kustomization.yaml
@@ -2,4 +2,4 @@ bases:
   - ../rbac
   - ../manager
 
-namespace: caps-system
+namespace: sidero-system

--- a/app/metal-controller-manager/config/kustomization.yaml
+++ b/app/metal-controller-manager/config/kustomization.yaml
@@ -64,4 +64,4 @@ vars:
 #    version: v1
 #    name: webhook-service
 
-namespace: caps-system
+namespace: sidero-system

--- a/app/metal-metadata-server/config/kustomization.yaml
+++ b/app/metal-metadata-server/config/kustomization.yaml
@@ -7,4 +7,4 @@ bases:
 
 namePrefix: sidero-
 
-namespace: caps-system
+namespace: sidero-system

--- a/config/namespace.yaml
+++ b/config/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: caps-system
+  name: sidero-system

--- a/docs/website/content/docs/bootstrapping.md
+++ b/docs/website/content/docs/bootstrapping.md
@@ -127,23 +127,23 @@ Update the metadata server component with the following patches:
 
 ```bash
 ## Update args to use 9091 for port
-kubectl patch deploy -n caps-system sidero-metadata-server --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args", "value": ["--port=9091"]}]'
+kubectl patch deploy -n sidero-system sidero-metadata-server --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args", "value": ["--port=9091"]}]'
 
 ## Tweak container port to match
-kubectl patch deploy -n caps-system sidero-metadata-server --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/ports", "value": [{"containerPort": 9091,"name": "http"}]}]'
+kubectl patch deploy -n sidero-system sidero-metadata-server --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/ports", "value": [{"containerPort": 9091,"name": "http"}]}]'
 
 ## Use host networking
-kubectl patch deploy -n caps-system sidero-metadata-server --type='json' -p='[{"op": "add", "path": "/spec/template/spec/hostNetwork", "value": true}]'
+kubectl patch deploy -n sidero-system sidero-metadata-server --type='json' -p='[{"op": "add", "path": "/spec/template/spec/hostNetwork", "value": true}]'
 ```
 
 ### Patch the Metal Controller Manager
 
 ```bash
 ## Update args to specify the api endpoint to use for registration
-kubectl patch deploy -n caps-system sidero-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1/args", "value": ["--api-endpoint='$PUBLIC_IP'","--metrics-addr=127.0.0.1:8080","--enable-leader-election"]}]'
+kubectl patch deploy -n sidero-system sidero-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1/args", "value": ["--api-endpoint='$PUBLIC_IP'","--metrics-addr=127.0.0.1:8080","--enable-leader-election"]}]'
 
 ## Use host networking
-kubectl patch deploy -n caps-system sidero-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/hostNetwork", "value": true}]'
+kubectl patch deploy -n sidero-system sidero-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/hostNetwork", "value": true}]'
 ```
 
 ## Register the Servers

--- a/docs/website/content/docs/first-cluster.md
+++ b/docs/website/content/docs/first-cluster.md
@@ -26,7 +26,7 @@ Metal Controller Manager:
 
 ```bash
 ## Use host networking
-kubectl patch deploy -n caps-system sidero-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/hostNetwork", "value": true}]'
+kubectl patch deploy -n sidero-system sidero-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/hostNetwork", "value": true}]'
 ```
 
 Metadata Server:


### PR DESCRIPTION
This PR reverts commit f850aa348732510b742ace5e3ea923ee68cb1b73.
The change of namespace led to unexpected behavior with upstream
clusterctl and would cause confusion for end users.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>