### PR TITLE
chore: add additional logging for metadata server

### DIFF
--- a/app/metal-metadata-server/main.go
+++ b/app/metal-metadata-server/main.go
@@ -37,6 +37,11 @@ const (
 	metalVersion = "v1alpha1"
 )
 
+func throwError(w http.ResponseWriter, code int, err error) {
+	http.Error(w, err.Error(), code)
+	log.Println(err)
+}
+
 func main() {
 	kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	port = flag.String("port", "8080", "port to use for serving metadata")
@@ -54,14 +59,28 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 	uuid := vals.Get("uuid")
 
 	if len(uuid) == 0 {
-		http.Error(w, "uuid param not found", 500)
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"received metadata request with empty uuid",
+			),
+		)
 	}
 
 	log.Printf("received metadata request for uuid: %s", uuid)
 
 	k8sClient, err := client.NewClient(kubeconfig)
 	if err != nil {
-		http.Error(w, "failed to create k8s clientset", 500)
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure talking to kubernetes: %s",
+				err,
+			),
+		)
+
 		return
 	}
 
@@ -91,11 +110,18 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 	metalMachineList, err := k8sClient.Resource(metalMachineGVR).Namespace("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			http.Error(w, err.Error(), 404)
+			throwError(
+				w,
+				http.StatusNotFound,
+				fmt.Errorf(
+					"failure listing metal machines",
+				),
+			)
+
 			return
 		}
 
-		http.Error(w, err.Error(), 500)
+		throwError(w, http.StatusInternalServerError, fmt.Errorf("failure listing metal machines: %w", err))
 
 		return
 	}
@@ -104,7 +130,14 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 	for _, metalMachine := range metalMachineList.Items {
 		serverRefString, _, err := unstructured.NestedString(metalMachine.Object, "spec", "serverRef", "name")
 		if err != nil {
-			http.Error(w, err.Error(), 500)
+			throwError(w,
+				http.StatusInternalServerError,
+				fmt.Errorf(
+					"failure finding serverRef name from metal machine %s/%s: %s",
+					metalMachine.GetNamespace(),
+					metalMachine.GetName(),
+					err,
+				))
 
 			return
 		}
@@ -118,13 +151,28 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 		if serverRefString == uuid {
 			ownerList, present, err := unstructured.NestedSlice(metalMachine.Object, "metadata", "ownerReferences")
 			if err != nil {
-				http.Error(w, err.Error(), 500)
+				throwError(
+					w,
+					http.StatusInternalServerError,
+					fmt.Errorf(
+						"failure fetching ownerRefs from metal machine %s/%s: %s",
+						metalMachine.GetNamespace(),
+						metalMachine.GetName(),
+						err,
+					),
+				)
 
 				return
 			}
 
 			if !present {
-				http.Error(w, "ownerRefList not found for metalMachine", 404)
+				throwError(
+					w,
+					http.StatusNotFound,
+					fmt.Errorf(
+						"ownerRefList not found for metalMachine",
+					),
+				)
 
 				return
 			}
@@ -136,33 +184,61 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 
 				err = runtime.DefaultUnstructuredConverter.FromUnstructured(ownerItem.(map[string]interface{}), tempOwnerRef)
 				if err != nil {
-					http.Error(w, err.Error(), 500)
+					throwError(
+						w,
+						http.StatusInternalServerError,
+						fmt.Errorf("failure converting ownerItem to ownerRef: %s", err),
+					)
 
 					return
 				}
 
 				if tempOwnerRef.APIVersion == "cluster.x-k8s.io/"+capiVersion && tempOwnerRef.Kind == "Machine" {
 					ownerRef = tempOwnerRef
-
 					break
 				}
 			}
 
 			if ownerRef == nil {
-				http.Error(w, "unable to find ownerref for metalMachine", 500)
+				throwError(
+					w,
+					http.StatusNotFound,
+					fmt.Errorf(
+						"no ownerrefs for metal machine %s/%s",
+						metalMachine.GetNamespace(),
+						metalMachine.GetName(),
+					),
+				)
 
 				return
 			}
 
 			metalMachineNS, present, err := unstructured.NestedString(metalMachine.Object, "metadata", "namespace")
 			if err != nil {
-				http.Error(w, err.Error(), 500)
+				throwError(
+					w,
+					http.StatusInternalServerError,
+					fmt.Errorf(
+						"failure fetching namespace for metal machine %s/%s: %s",
+						metalMachine.GetNamespace(),
+						metalMachine.GetName(),
+						err,
+					),
+				)
 
 				return
 			}
 
 			if !present {
-				http.Error(w, "namespace not found for metalMachine", 404)
+				throwError(
+					w,
+					http.StatusNotFound,
+					fmt.Errorf(
+						"no namespace present for metal machine %s/%s",
+						metalMachine.GetNamespace(),
+						metalMachine.GetName(),
+					),
+				)
 
 				return
 			}
@@ -170,58 +246,137 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 			machineData, err := k8sClient.Resource(capiMachineGVR).Namespace(metalMachineNS).Get(ctx, ownerRef.Name, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
-					http.Error(w, "machine not found", 404)
+					throwError(
+						w,
+						http.StatusNotFound,
+						fmt.Errorf(
+							"owner machine %s/%s not found",
+							metalMachineNS,
+							ownerRef.Name,
+						),
+					)
 
 					return
 				}
 
-				http.Error(w, err.Error(), 500)
+				throwError(
+					w,
+					http.StatusInternalServerError,
+					fmt.Errorf(
+						"failure fetching machine based on owner ref %s: %s",
+						ownerRef.Name,
+						err,
+					),
+				)
 
 				return
 			}
 
 			bootstrapSecretName, present, err := unstructured.NestedString(machineData.Object, "spec", "bootstrap", "dataSecretName")
 			if err != nil {
-				http.Error(w, err.Error(), 500)
+				throwError(
+					w,
+					http.StatusInternalServerError,
+					fmt.Errorf(
+						"failure fetching bootstrap dataSecretName from machine %s/%s: %s",
+						machineData.GetNamespace(),
+						machineData.GetName(),
+						err,
+					),
+				)
 
 				return
 			}
 
 			if !present {
-				http.Error(w, "dataSecretName not found for machine", 404)
+				throwError(
+					w,
+					http.StatusNotFound,
+					fmt.Errorf(
+						"no dataSecretName present for machine %s/%s: %s",
+						machineData.GetNamespace(),
+						machineData.GetName(),
+						err,
+					),
+				)
 
 				return
 			}
 
-			bootstrapSecretData, err := k8sClient.Resource(secretGVR).Namespace(metalMachineNS).Get(ctx, bootstrapSecretName, metav1.GetOptions{})
+			bootstrapSecretData, err := k8sClient.Resource(secretGVR).Namespace(metalMachineNS).Get(
+				ctx,
+				bootstrapSecretName,
+				metav1.GetOptions{},
+			)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
-					http.Error(w, "bootstrap secret not found", 404)
+					throwError(
+						w,
+						http.StatusNotFound,
+						fmt.Errorf(
+							"bootstrap secret %s/%s not found",
+							metalMachineNS,
+							bootstrapSecretName,
+						),
+					)
 
 					return
 				}
 
-				http.Error(w, err.Error(), 500)
+				throwError(
+					w,
+					http.StatusInternalServerError,
+					fmt.Errorf(
+						"failure fetching bootstrap secret data from secret %s/%s: %s",
+						metalMachineNS,
+						bootstrapSecretName,
+						err,
+					),
+				)
 
 				return
 			}
 
 			bootstrapData, present, err := unstructured.NestedString(bootstrapSecretData.Object, "data", "value")
 			if err != nil {
-				http.Error(w, err.Error(), 500)
+				throwError(
+					w,
+					http.StatusInternalServerError,
+					fmt.Errorf(
+						"failure fetching value key from bootstrap secret %s/%s: %s",
+						bootstrapSecretData.GetName(),
+						bootstrapSecretData.GetNamespace(),
+						err,
+					),
+				)
 
 				return
 			}
 
 			if !present {
-				http.Error(w, "bootstrap data not found", 404)
+				throwError(
+					w,
+					http.StatusNotFound,
+					fmt.Errorf(
+						"no bootstrap data found in value key of secret %s/%s",
+						bootstrapSecretData.GetName(),
+						bootstrapSecretData.GetNamespace(),
+					),
+				)
 
 				return
 			}
 
 			decodedData, err := base64.StdEncoding.DecodeString(bootstrapData)
 			if err != nil {
-				http.Error(w, err.Error(), 500)
+				throwError(
+					w,
+					http.StatusInternalServerError,
+					fmt.Errorf(
+						"failure decoding base64 from bootstrap data: %s",
+						err,
+					),
+				)
 
 				return
 			}
@@ -229,7 +384,15 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 			// Convert server uuid to unstructured obj and then to structured obj.
 			serverRef, err := k8sClient.Resource(serverGVR).Get(ctx, serverRefString, metav1.GetOptions{})
 			if err != nil {
-				http.Error(w, err.Error(), 500)
+				throwError(
+					w,
+					http.StatusInternalServerError,
+					fmt.Errorf(
+						"failure fetching server %s: %s",
+						serverRefString,
+						err,
+					),
+				)
 
 				return
 			}
@@ -238,7 +401,15 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(serverRef.UnstructuredContent(), serverObj)
 			if err != nil {
-				http.Error(w, err.Error(), 500)
+				throwError(
+					w,
+					http.StatusInternalServerError,
+					fmt.Errorf(
+						"failure converting server to metalv1alpha1.Server type %s: %s",
+						serverRefString,
+						err,
+					),
+				)
 
 				return
 			}
@@ -247,35 +418,72 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 			if len(serverObj.Spec.ConfigPatches) > 0 {
 				marshalledPatches, err := json.Marshal(serverObj.Spec.ConfigPatches)
 				if err != nil {
-					http.Error(w, err.Error(), 500)
+					throwError(
+						w,
+						http.StatusInternalServerError,
+						fmt.Errorf(
+							"failure marshalling config patches from server %s: %s",
+							serverObj.Name,
+							err,
+						),
+					)
 
 					return
 				}
 
 				jsonDecodedData, err := yaml.YAMLToJSON(decodedData)
 				if err != nil {
-					http.Error(w, err.Error(), 500)
+					throwError(
+						w,
+						http.StatusInternalServerError,
+						fmt.Errorf(
+							"failure converting bootstrap data to json: %s",
+							err,
+						),
+					)
 
 					return
 				}
 
 				patch, err := jsonpatch.DecodePatch(marshalledPatches)
 				if err != nil {
-					http.Error(w, err.Error(), 500)
+					throwError(
+						w,
+						http.StatusInternalServerError,
+						fmt.Errorf(
+							"failure decoding config patches from server %s to rfc6902 patch: %s",
+							serverObj.Name,
+							err,
+						),
+					)
 
 					return
 				}
 
 				jsonDecodedData, err = patch.Apply(jsonDecodedData)
 				if err != nil {
-					http.Error(w, err.Error(), 500)
+					throwError(
+						w,
+						http.StatusInternalServerError,
+						fmt.Errorf(
+							"failure applying rfc6902 patches to machine config: %s",
+							err,
+						),
+					)
 
 					return
 				}
 
 				decodedData, err = yaml.JSONToYAML(jsonDecodedData)
 				if err != nil {
-					http.Error(w, err.Error(), 500)
+					throwError(
+						w,
+						http.StatusInternalServerError,
+						fmt.Errorf(
+							"failure converting bootstrap data from json to yaml: %s",
+							err,
+						),
+					)
 
 					return
 				}
@@ -284,7 +492,14 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 			// Append or add a node label to kubelet extra args
 			configStruct, err := config.NewFromBytes(decodedData)
 			if err != nil {
-				http.Error(w, err.Error(), 500)
+				throwError(
+					w,
+					http.StatusInternalServerError,
+					fmt.Errorf(
+						"failure creating config struct: %s",
+						err,
+					),
+				)
 
 				return
 			}
@@ -303,7 +518,14 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 
 				decodedData, err = config.Bytes()
 				if err != nil {
-					http.Error(w, err.Error(), 500)
+					throwError(
+						w,
+						http.StatusInternalServerError,
+						fmt.Errorf(
+							"failure converting config to bytes: %s",
+							err,
+						),
+					)
 
 					return
 				}
@@ -319,5 +541,12 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Made it through all metal machines w/ no result
-	http.Error(w, "matching machine not found", 404)
+	throwError(
+		w,
+		http.StatusNotFound,
+		fmt.Errorf(
+			"failure finding matching metal machine for uuid: %q",
+			uuid,
+		),
+	)
 }


### PR DESCRIPTION
This PR adds a bunch of additional logging for the metadata server. This
is an attempt to make it clearer when we can't lookup a server or
bootstrap data for any given reason.

Will close #59 
Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>