### PR TITLE
feat: allow qualifers to be partially equal

### DIFF
--- a/app/metal-controller-manager/api/v1alpha1/server_types_test.go
+++ b/app/metal-controller-manager/api/v1alpha1/server_types_test.go
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// nolint: scopelint
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/talos-systems/sidero/app/metal-controller-manager/api/v1alpha1"
+)
+
+func Test_partialEqual(t *testing.T) {
+	type args struct {
+		a interface{}
+		b interface{}
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "defaults are partially equal",
+			args: args{
+				a: v1alpha1.CPUInformation{},
+				b: v1alpha1.CPUInformation{},
+			},
+			want: true,
+		},
+		{
+			name: "is partially equal",
+			args: args{
+				a: v1alpha1.CPUInformation{
+					Manufacturer: "QEMU",
+					// Skip Version to indicate that we don't want to compare it.
+				},
+				b: v1alpha1.CPUInformation{
+					Manufacturer: "QEMU",
+					Version:      "1.2.0",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "is not partially equal",
+			args: args{
+				a: v1alpha1.CPUInformation{
+					Manufacturer: "QEMU",
+					Version:      "1.0.0",
+				},
+				b: v1alpha1.CPUInformation{
+					Manufacturer: "QEMU",
+					Version:      "1.2.0",
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := v1alpha1.PartialEqual(tt.args.a, tt.args.b); got != tt.want {
+				t.Errorf("partialEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/app/metal-controller-manager/controllers/serverclass_controller.go
+++ b/app/metal-controller-manager/controllers/serverclass_controller.go
@@ -7,7 +7,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -61,7 +60,7 @@ func (sr *serverResults) filterCPU(filters []metalv1alpha1.CPUInformation) serve
 		var match bool
 
 		for _, cpu := range filters {
-			if server.Spec.CPU != nil && reflect.DeepEqual(cpu, *server.Spec.CPU) {
+			if server.Spec.CPU != nil && cpu.PartialEqual(server.Spec.CPU) {
 				match = true
 
 				break
@@ -86,7 +85,7 @@ func (sr *serverResults) filterSysInfo(filters []metalv1alpha1.SystemInformation
 		var match bool
 
 		for _, sysInfo := range filters {
-			if server.Spec.SystemInformation != nil && reflect.DeepEqual(sysInfo, *server.Spec.SystemInformation) {
+			if server.Spec.SystemInformation != nil && sysInfo.PartialEqual(server.Spec.SystemInformation) {
 				match = true
 				break
 			}


### PR DESCRIPTION
Instead of requiring a complete match of qualifiers, we now support the ability
to do partial matching. This means users can omit fiels in the CPU and System
Information qualifiers, and it will be a valid qualifier. Prior to this, every
field had to match.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
