### PR TITLE
fix: ensure proper checking of "in-use" status when fetching metadata

### DIFF
--- a/app/metal-metadata-server/main.go
+++ b/app/metal-metadata-server/main.go
@@ -66,6 +66,8 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 				"received metadata request with empty uuid",
 			),
 		)
+
+		return
 	}
 
 	log.Printf("received metadata request for uuid: %s", uuid)
@@ -126,7 +128,11 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Range through all metalMachines, seeing if we can match inventory by UUID
+	numMatchingMachines := 0
+
+	var matchingMetalMachine unstructured.Unstructured
+
+	// range through all metalmachines and find all that match our server string
 	for _, metalMachine := range metalMachineList.Items {
 		serverRefString, _, err := unstructured.NestedString(metalMachine.Object, "spec", "serverRef", "name")
 		if err != nil {
@@ -147,406 +153,431 @@ func FetchConfig(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		// If ref matches, fetch the bootstrap data from machine resource that owns this metal machine
 		if serverRefString == uuid {
-			ownerList, present, err := unstructured.NestedSlice(metalMachine.Object, "metadata", "ownerReferences")
-			if err != nil {
-				throwError(
-					w,
-					http.StatusInternalServerError,
-					fmt.Errorf(
-						"failure fetching ownerRefs from metal machine %s/%s: %s",
-						metalMachine.GetNamespace(),
-						metalMachine.GetName(),
-						err,
-					),
-				)
+			numMatchingMachines++
 
-				return
-			}
+			matchingMetalMachine = metalMachine
+		}
+	}
 
-			if !present {
-				throwError(
-					w,
-					http.StatusNotFound,
-					fmt.Errorf(
-						"ownerRefList not found for metalMachine",
-					),
-				)
+	// bail early if we have multiple matches or no matches
+	switch {
+	case numMatchingMachines > 1:
+		throwError(
+			w,
+			http.StatusNotFound,
+			fmt.Errorf(
+				"multiple matching metal machines for uuid %q, possible orphaned cluster",
+				uuid,
+			),
+		)
 
-				return
-			}
+		return
+	case numMatchingMachines == 0:
+		throwError(
+			w,
+			http.StatusNotFound,
+			fmt.Errorf(
+				"failure finding matching metal machine for uuid: %q",
+				uuid,
+			),
+		)
 
-			var ownerRef *metav1.OwnerReference
+		return
+	}
 
-			for _, ownerItem := range ownerList {
-				tempOwnerRef := &metav1.OwnerReference{}
+	// If we have a match, fetch the bootstrap data from machine resource that owns this metal machine
+	ownerList, present, err := unstructured.NestedSlice(matchingMetalMachine.Object, "metadata", "ownerReferences")
+	if err != nil {
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure fetching ownerRefs from metal machine %s/%s: %s",
+				matchingMetalMachine.GetNamespace(),
+				matchingMetalMachine.GetName(),
+				err,
+			),
+		)
 
-				err = runtime.DefaultUnstructuredConverter.FromUnstructured(ownerItem.(map[string]interface{}), tempOwnerRef)
-				if err != nil {
-					throwError(
-						w,
-						http.StatusInternalServerError,
-						fmt.Errorf("failure converting ownerItem to ownerRef: %s", err),
-					)
+		return
+	}
 
-					return
-				}
+	if !present {
+		throwError(
+			w,
+			http.StatusNotFound,
+			fmt.Errorf(
+				"ownerRefList not found for metalMachine",
+			),
+		)
 
-				if tempOwnerRef.APIVersion == "cluster.x-k8s.io/"+capiVersion && tempOwnerRef.Kind == "Machine" {
-					ownerRef = tempOwnerRef
-					break
-				}
-			}
+		return
+	}
 
-			if ownerRef == nil {
-				throwError(
-					w,
-					http.StatusNotFound,
-					fmt.Errorf(
-						"no ownerrefs for metal machine %s/%s",
-						metalMachine.GetNamespace(),
-						metalMachine.GetName(),
-					),
-				)
+	var ownerRef *metav1.OwnerReference
 
-				return
-			}
+	for _, ownerItem := range ownerList {
+		tempOwnerRef := &metav1.OwnerReference{}
 
-			metalMachineNS, present, err := unstructured.NestedString(metalMachine.Object, "metadata", "namespace")
-			if err != nil {
-				throwError(
-					w,
-					http.StatusInternalServerError,
-					fmt.Errorf(
-						"failure fetching namespace for metal machine %s/%s: %s",
-						metalMachine.GetNamespace(),
-						metalMachine.GetName(),
-						err,
-					),
-				)
-
-				return
-			}
-
-			if !present {
-				throwError(
-					w,
-					http.StatusNotFound,
-					fmt.Errorf(
-						"no namespace present for metal machine %s/%s",
-						metalMachine.GetNamespace(),
-						metalMachine.GetName(),
-					),
-				)
-
-				return
-			}
-
-			machineData, err := k8sClient.Resource(capiMachineGVR).Namespace(metalMachineNS).Get(ctx, ownerRef.Name, metav1.GetOptions{})
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					throwError(
-						w,
-						http.StatusNotFound,
-						fmt.Errorf(
-							"owner machine %s/%s not found",
-							metalMachineNS,
-							ownerRef.Name,
-						),
-					)
-
-					return
-				}
-
-				throwError(
-					w,
-					http.StatusInternalServerError,
-					fmt.Errorf(
-						"failure fetching machine based on owner ref %s: %s",
-						ownerRef.Name,
-						err,
-					),
-				)
-
-				return
-			}
-
-			bootstrapSecretName, present, err := unstructured.NestedString(machineData.Object, "spec", "bootstrap", "dataSecretName")
-			if err != nil {
-				throwError(
-					w,
-					http.StatusInternalServerError,
-					fmt.Errorf(
-						"failure fetching bootstrap dataSecretName from machine %s/%s: %s",
-						machineData.GetNamespace(),
-						machineData.GetName(),
-						err,
-					),
-				)
-
-				return
-			}
-
-			if !present {
-				throwError(
-					w,
-					http.StatusNotFound,
-					fmt.Errorf(
-						"no dataSecretName present for machine %s/%s: %s",
-						machineData.GetNamespace(),
-						machineData.GetName(),
-						err,
-					),
-				)
-
-				return
-			}
-
-			bootstrapSecretData, err := k8sClient.Resource(secretGVR).Namespace(metalMachineNS).Get(
-				ctx,
-				bootstrapSecretName,
-				metav1.GetOptions{},
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(ownerItem.(map[string]interface{}), tempOwnerRef)
+		if err != nil {
+			throwError(
+				w,
+				http.StatusInternalServerError,
+				fmt.Errorf("failure converting ownerItem to ownerRef: %s", err),
 			)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					throwError(
-						w,
-						http.StatusNotFound,
-						fmt.Errorf(
-							"bootstrap secret %s/%s not found",
-							metalMachineNS,
-							bootstrapSecretName,
-						),
-					)
 
-					return
-				}
+			return
+		}
 
-				throwError(
-					w,
-					http.StatusInternalServerError,
-					fmt.Errorf(
-						"failure fetching bootstrap secret data from secret %s/%s: %s",
-						metalMachineNS,
-						bootstrapSecretName,
-						err,
-					),
-				)
+		if tempOwnerRef.APIVersion == "cluster.x-k8s.io/"+capiVersion && tempOwnerRef.Kind == "Machine" {
+			ownerRef = tempOwnerRef
+			break
+		}
+	}
 
-				return
-			}
+	if ownerRef == nil {
+		throwError(
+			w,
+			http.StatusNotFound,
+			fmt.Errorf(
+				"no ownerrefs for metal machine %s/%s",
+				matchingMetalMachine.GetNamespace(),
+				matchingMetalMachine.GetName(),
+			),
+		)
 
-			bootstrapData, present, err := unstructured.NestedString(bootstrapSecretData.Object, "data", "value")
-			if err != nil {
-				throwError(
-					w,
-					http.StatusInternalServerError,
-					fmt.Errorf(
-						"failure fetching value key from bootstrap secret %s/%s: %s",
-						bootstrapSecretData.GetName(),
-						bootstrapSecretData.GetNamespace(),
-						err,
-					),
-				)
+		return
+	}
 
-				return
-			}
+	metalMachineNS, present, err := unstructured.NestedString(matchingMetalMachine.Object, "metadata", "namespace")
+	if err != nil {
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure fetching namespace for metal machine %s/%s: %s",
+				matchingMetalMachine.GetNamespace(),
+				matchingMetalMachine.GetName(),
+				err,
+			),
+		)
 
-			if !present {
-				throwError(
-					w,
-					http.StatusNotFound,
-					fmt.Errorf(
-						"no bootstrap data found in value key of secret %s/%s",
-						bootstrapSecretData.GetName(),
-						bootstrapSecretData.GetNamespace(),
-					),
-				)
+		return
+	}
 
-				return
-			}
+	if !present {
+		throwError(
+			w,
+			http.StatusNotFound,
+			fmt.Errorf(
+				"no namespace present for metal machine %s/%s",
+				matchingMetalMachine.GetNamespace(),
+				matchingMetalMachine.GetName(),
+			),
+		)
 
-			decodedData, err := base64.StdEncoding.DecodeString(bootstrapData)
-			if err != nil {
-				throwError(
-					w,
-					http.StatusInternalServerError,
-					fmt.Errorf(
-						"failure decoding base64 from bootstrap data: %s",
-						err,
-					),
-				)
+		return
+	}
 
-				return
-			}
+	machineData, err := k8sClient.Resource(capiMachineGVR).Namespace(metalMachineNS).Get(ctx, ownerRef.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			throwError(
+				w,
+				http.StatusNotFound,
+				fmt.Errorf(
+					"owner machine %s/%s not found",
+					metalMachineNS,
+					ownerRef.Name,
+				),
+			)
 
-			// Convert server uuid to unstructured obj and then to structured obj.
-			serverRef, err := k8sClient.Resource(serverGVR).Get(ctx, serverRefString, metav1.GetOptions{})
-			if err != nil {
-				throwError(
-					w,
-					http.StatusInternalServerError,
-					fmt.Errorf(
-						"failure fetching server %s: %s",
-						serverRefString,
-						err,
-					),
-				)
+			return
+		}
 
-				return
-			}
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure fetching machine based on owner ref %s: %s",
+				ownerRef.Name,
+				err,
+			),
+		)
 
-			serverObj := &metalv1alpha1.Server{}
+		return
+	}
 
-			err = runtime.DefaultUnstructuredConverter.FromUnstructured(serverRef.UnstructuredContent(), serverObj)
-			if err != nil {
-				throwError(
-					w,
-					http.StatusInternalServerError,
-					fmt.Errorf(
-						"failure converting server to metalv1alpha1.Server type %s: %s",
-						serverRefString,
-						err,
-					),
-				)
+	bootstrapSecretName, present, err := unstructured.NestedString(machineData.Object, "spec", "bootstrap", "dataSecretName")
+	if err != nil {
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure fetching bootstrap dataSecretName from machine %s/%s: %s",
+				machineData.GetNamespace(),
+				machineData.GetName(),
+				err,
+			),
+		)
 
-				return
-			}
+		return
+	}
 
-			// Handle patches added to server object
-			if len(serverObj.Spec.ConfigPatches) > 0 {
-				marshalledPatches, err := json.Marshal(serverObj.Spec.ConfigPatches)
-				if err != nil {
-					throwError(
-						w,
-						http.StatusInternalServerError,
-						fmt.Errorf(
-							"failure marshalling config patches from server %s: %s",
-							serverObj.Name,
-							err,
-						),
-					)
+	if !present {
+		throwError(
+			w,
+			http.StatusNotFound,
+			fmt.Errorf(
+				"no dataSecretName present for machine %s/%s: %s",
+				machineData.GetNamespace(),
+				machineData.GetName(),
+				err,
+			),
+		)
 
-					return
-				}
+		return
+	}
 
-				jsonDecodedData, err := yaml.YAMLToJSON(decodedData)
-				if err != nil {
-					throwError(
-						w,
-						http.StatusInternalServerError,
-						fmt.Errorf(
-							"failure converting bootstrap data to json: %s",
-							err,
-						),
-					)
+	bootstrapSecretData, err := k8sClient.Resource(secretGVR).Namespace(metalMachineNS).Get(
+		ctx,
+		bootstrapSecretName,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			throwError(
+				w,
+				http.StatusNotFound,
+				fmt.Errorf(
+					"bootstrap secret %s/%s not found",
+					metalMachineNS,
+					bootstrapSecretName,
+				),
+			)
 
-					return
-				}
+			return
+		}
 
-				patch, err := jsonpatch.DecodePatch(marshalledPatches)
-				if err != nil {
-					throwError(
-						w,
-						http.StatusInternalServerError,
-						fmt.Errorf(
-							"failure decoding config patches from server %s to rfc6902 patch: %s",
-							serverObj.Name,
-							err,
-						),
-					)
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure fetching bootstrap secret data from secret %s/%s: %s",
+				metalMachineNS,
+				bootstrapSecretName,
+				err,
+			),
+		)
 
-					return
-				}
+		return
+	}
 
-				jsonDecodedData, err = patch.Apply(jsonDecodedData)
-				if err != nil {
-					throwError(
-						w,
-						http.StatusInternalServerError,
-						fmt.Errorf(
-							"failure applying rfc6902 patches to machine config: %s",
-							err,
-						),
-					)
+	bootstrapData, present, err := unstructured.NestedString(bootstrapSecretData.Object, "data", "value")
+	if err != nil {
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure fetching value key from bootstrap secret %s/%s: %s",
+				bootstrapSecretData.GetName(),
+				bootstrapSecretData.GetNamespace(),
+				err,
+			),
+		)
 
-					return
-				}
+		return
+	}
 
-				decodedData, err = yaml.JSONToYAML(jsonDecodedData)
-				if err != nil {
-					throwError(
-						w,
-						http.StatusInternalServerError,
-						fmt.Errorf(
-							"failure converting bootstrap data from json to yaml: %s",
-							err,
-						),
-					)
+	if !present {
+		throwError(
+			w,
+			http.StatusNotFound,
+			fmt.Errorf(
+				"no bootstrap data found in value key of secret %s/%s",
+				bootstrapSecretData.GetName(),
+				bootstrapSecretData.GetNamespace(),
+			),
+		)
 
-					return
-				}
-			}
+		return
+	}
 
-			// Append or add a node label to kubelet extra args
-			configStruct, err := config.NewFromBytes(decodedData)
-			if err != nil {
-				throwError(
-					w,
-					http.StatusInternalServerError,
-					fmt.Errorf(
-						"failure creating config struct: %s",
-						err,
-					),
-				)
+	decodedData, err := base64.StdEncoding.DecodeString(bootstrapData)
+	if err != nil {
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure decoding base64 from bootstrap data: %s",
+				err,
+			),
+		)
 
-				return
-			}
+		return
+	}
 
-			// nolint: gocritic
-			switch config := configStruct.(type) {
-			case *v1alpha1.Config:
-				if _, ok := config.MachineConfig.MachineKubelet.KubeletExtraArgs["node-labels"]; ok {
-					config.MachineConfig.MachineKubelet.KubeletExtraArgs["node-labels"] += fmt.Sprintf(",metal.sidero.dev/uuid=%s", serverObj.Name)
-				} else {
-					if config.MachineConfig.MachineKubelet.KubeletExtraArgs == nil {
-						config.MachineConfig.MachineKubelet.KubeletExtraArgs = make(map[string]string)
-					}
-					config.MachineConfig.MachineKubelet.KubeletExtraArgs["node-labels"] = fmt.Sprintf("metal.sidero.dev/uuid=%s", serverObj.Name)
-				}
+	// Convert server uuid to unstructured obj and then to structured obj.
+	serverRef, err := k8sClient.Resource(serverGVR).Get(ctx, uuid, metav1.GetOptions{})
+	if err != nil {
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure fetching server %s: %s",
+				uuid,
+				err,
+			),
+		)
 
-				decodedData, err = config.Bytes()
-				if err != nil {
-					throwError(
-						w,
-						http.StatusInternalServerError,
-						fmt.Errorf(
-							"failure converting config to bytes: %s",
-							err,
-						),
-					)
+		return
+	}
 
-					return
-				}
-			}
+	serverObj := &metalv1alpha1.Server{}
 
-			// Finally return config data
-			if _, err = w.Write(decodedData); err != nil {
-				log.Printf("Failed to write data: %v", err)
-			}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(serverRef.UnstructuredContent(), serverObj)
+	if err != nil {
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure converting server to metalv1alpha1.Server type %s: %s",
+				uuid,
+				err,
+			),
+		)
+
+		return
+	}
+
+	// Handle patches added to server object
+	if len(serverObj.Spec.ConfigPatches) > 0 {
+		marshalledPatches, err := json.Marshal(serverObj.Spec.ConfigPatches)
+		if err != nil {
+			throwError(
+				w,
+				http.StatusInternalServerError,
+				fmt.Errorf(
+					"failure marshalling config patches from server %s: %s",
+					serverObj.Name,
+					err,
+				),
+			)
+
+			return
+		}
+
+		jsonDecodedData, err := yaml.YAMLToJSON(decodedData)
+		if err != nil {
+			throwError(
+				w,
+				http.StatusInternalServerError,
+				fmt.Errorf(
+					"failure converting bootstrap data to json: %s",
+					err,
+				),
+			)
+
+			return
+		}
+
+		patch, err := jsonpatch.DecodePatch(marshalledPatches)
+		if err != nil {
+			throwError(
+				w,
+				http.StatusInternalServerError,
+				fmt.Errorf(
+					"failure decoding config patches from server %s to rfc6902 patch: %s",
+					serverObj.Name,
+					err,
+				),
+			)
+
+			return
+		}
+
+		jsonDecodedData, err = patch.Apply(jsonDecodedData)
+		if err != nil {
+			throwError(
+				w,
+				http.StatusInternalServerError,
+				fmt.Errorf(
+					"failure applying rfc6902 patches to machine config: %s",
+					err,
+				),
+			)
+
+			return
+		}
+
+		decodedData, err = yaml.JSONToYAML(jsonDecodedData)
+		if err != nil {
+			throwError(
+				w,
+				http.StatusInternalServerError,
+				fmt.Errorf(
+					"failure converting bootstrap data from json to yaml: %s",
+					err,
+				),
+			)
 
 			return
 		}
 	}
 
-	// Made it through all metal machines w/ no result
-	throwError(
-		w,
-		http.StatusNotFound,
-		fmt.Errorf(
-			"failure finding matching metal machine for uuid: %q",
-			uuid,
-		),
-	)
+	// Append or add a node label to kubelet extra args
+	configStruct, err := config.NewFromBytes(decodedData)
+	if err != nil {
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"failure creating config struct: %s",
+				err,
+			),
+		)
+
+		return
+	}
+
+	switch config := configStruct.(type) {
+	case *v1alpha1.Config:
+		if _, ok := config.MachineConfig.MachineKubelet.KubeletExtraArgs["node-labels"]; ok {
+			config.MachineConfig.MachineKubelet.KubeletExtraArgs["node-labels"] += fmt.Sprintf(",metal.sidero.dev/uuid=%s", serverObj.Name)
+		} else {
+			if config.MachineConfig.MachineKubelet.KubeletExtraArgs == nil {
+				config.MachineConfig.MachineKubelet.KubeletExtraArgs = make(map[string]string)
+			}
+			config.MachineConfig.MachineKubelet.KubeletExtraArgs["node-labels"] = fmt.Sprintf("metal.sidero.dev/uuid=%s", serverObj.Name)
+		}
+
+		decodedData, err = config.Bytes()
+		if err != nil {
+			throwError(
+				w,
+				http.StatusInternalServerError,
+				fmt.Errorf(
+					"failure converting config to bytes: %s",
+					err,
+				),
+			)
+
+			return
+		}
+	default:
+		throwError(
+			w,
+			http.StatusInternalServerError,
+			fmt.Errorf(
+				"unknown config type",
+			),
+		)
+	}
+
+	// Finally return config data
+	if _, err = w.Write(decodedData); err != nil {
+		log.Printf("Failed to write data: %v", err)
+	}
 }


### PR DESCRIPTION
This PR fixes a bug where users could have orphaned metalmachines that still
had ownerrefs to a server that had alredy been made available for another
cluster. This led to incorrect metadata being returned. We now bail and
error early if we encounter multiple ownerrefs in the list pointing to
the same server.