### PR TITLE
fix: use proper context in metadata server

### DIFF
--- a/app/metal-metadata-server/main.go
+++ b/app/metal-metadata-server/main.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"flag"
@@ -52,7 +51,7 @@ func main() {
 }
 
 func FetchConfig(w http.ResponseWriter, r *http.Request) {
-	ctx := context.TODO()
+	ctx := r.Context()
 
 	vals := r.URL.Query()
 


### PR DESCRIPTION
This way (if context is used consistently) operation will be aborted
when client closes the connection.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>