### PR TITLE
fix: close file in TFTP handler

### DIFF
--- a/app/metal-controller-manager/internal/tftp/tftp_server.go
+++ b/app/metal-controller-manager/internal/tftp/tftp_server.go
@@ -26,6 +26,8 @@ func readHandler(filename string, rf io.ReaderFrom) error {
 		return err
 	}
 
+	defer file.Close()
+
 	n, err := rf.ReadFrom(file)
 	if err != nil {
 		log.Printf("%v", err)


### PR DESCRIPTION
Prevents file descriptor leak.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>