### PR TITLE
test: fix nil pointer panic

### DIFF
--- a/sfyra/pkg/tests/reset.go
+++ b/sfyra/pkg/tests/reset.go
@@ -34,6 +34,10 @@ func TestServerReset(ctx context.Context, metalClient client.Client, vmSet *vm.S
 		serverNamesToCheck := []string{}
 
 		for i := range machines.Items {
+			if machines.Items[i].Spec.ServerRef == nil {
+				continue
+			}
+
 			serverNamesToCheck = append(serverNamesToCheck, machines.Items[i].Spec.ServerRef.Name)
 
 			err = metalClient.Delete(ctx, &machines.Items[i])


### PR DESCRIPTION
We should ensure that the server ref is not nil.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
