### PR TITLE
test: use dedicated config for the sfyra tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ ARTIFACTS := _out
 PKGS ?= ./...
 TALOS_RELEASE ?= v0.7.0-alpha.2
 
+SFYRA_CLUSTERCTL_CONFIG ?= $(HOME)/.cluster-api/clusterctl.sfyra.yaml
+
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64
 PROGRESS ?= auto
@@ -126,11 +128,15 @@ sfyra: ## Build the Sfyra test binary.
 .PHONY: clusterctl-release
 clusterctl-release: release
 	@COMPONENTS_YAML="$(abspath $(ARTIFACTS)/infrastructure-sidero/$(TAG)/infrastructure-components.yaml)" \
+		CLUSTERCTL_CONFIG=$(SFYRA_CLUSTERCTL_CONFIG) \
 		./hack/scripts/generate-clusterctl-config.sh
 
 .PHONY: run-sfyra
 run-sfyra: talos-artifacts clusterctl-release
-	@ARTIFACTS=$(ARTIFACTS) TALOS_RELEASE=$(TALOS_RELEASE) ./hack/scripts/integration-test.sh
+	@ARTIFACTS=$(ARTIFACTS) \
+		CLUSTERCTL_CONFIG=$(SFYRA_CLUSTERCTL_CONFIG) \
+		TALOS_RELEASE=$(TALOS_RELEASE) \
+		./hack/scripts/integration-test.sh
 
 # Development
 

--- a/hack/scripts/generate-clusterctl-config.sh
+++ b/hack/scripts/generate-clusterctl-config.sh
@@ -2,9 +2,9 @@
 
 set -eou pipefail
 
-mkdir -p ~/.cluster-api
+mkdir -p `dirname "${CLUSTERCTL_CONFIG}"`
 
-cat > ~/.cluster-api/clusterctl.yaml <<EOF
+cat > "${CLUSTERCTL_CONFIG}" <<EOF
 providers:
   - name: "sidero"
     url: "file://${COMPONENTS_YAML}"

--- a/hack/scripts/integration-test.sh
+++ b/hack/scripts/integration-test.sh
@@ -43,5 +43,6 @@ ${PREFIX} "${INTEGRATION_TEST}" \
     -bootstrap-vmlinuz "${BOOTSTRAP_VMLINUZ}" \
     -bootstrap-installer "${BOOTSTRAP_INSTALLER}" \
     -talosctl-path "${TALOSCTL}" \
+    -clusterctl-config "${CLUSTERCTL_CONFIG}" \
     ${REGISTRY_MIRROR_FLAGS} \
     -test.v

--- a/sfyra/cmd/sfyra/main.go
+++ b/sfyra/cmd/sfyra/main.go
@@ -34,6 +34,7 @@ func main() {
 	flag.Var(&options.RegistryMirrors, "registry-mirrors", "registry mirrors to use")
 	flag.StringVar(&options.TalosKernelURL, "talos-kernel-url", options.TalosKernelURL, "Talos kernel image URL for Cluster API Environment")
 	flag.StringVar(&options.TalosInitrdURL, "talos-initrd-url", options.TalosInitrdURL, "Talos initramfs image URL for Cluster API Environment")
+	flag.StringVar(&options.ClusterctlConfigPath, "clusterctl-config", options.ClusterctlConfigPath, "path to the clusterctl config file")
 
 	testing.Init()
 
@@ -93,6 +94,7 @@ func main() {
 		}
 
 		clusterAPI, err := capi.NewManager(ctx, bootstrapCluster, capi.Options{
+			ClusterctlConfigPath:    options.ClusterctlConfigPath,
 			BootstrapProviders:      options.BootstrapProviders,
 			InfrastructureProviders: options.InfrastructureProviders,
 			ControlPlaneProviders:   options.ControlPlaneProviders,

--- a/sfyra/cmd/sfyra/options.go
+++ b/sfyra/cmd/sfyra/options.go
@@ -20,6 +20,7 @@ type Options struct {
 	TalosInitrdURL string
 	TalosInstaller string
 
+	ClusterctlConfigPath    string
 	BootstrapProviders      []string
 	InfrastructureProviders []string
 	ControlPlaneProviders   []string

--- a/sfyra/pkg/bootstrap/cluster.go
+++ b/sfyra/pkg/bootstrap/cluster.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -93,8 +92,6 @@ func (cluster *Cluster) Setup(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	log.Printf("cluster.options = %v", cluster.options)
 
 	cluster.stateDir = filepath.Join(defaultStateDir, "clusters")
 

--- a/sfyra/pkg/capi/capi.go
+++ b/sfyra/pkg/capi/capi.go
@@ -43,6 +43,7 @@ type Manager struct {
 
 // Options for the CAPI installer.
 type Options struct {
+	ClusterctlConfigPath    string
 	BootstrapProviders      []string
 	InfrastructureProviders []string
 	ControlPlaneProviders   []string
@@ -57,7 +58,7 @@ func NewManager(ctx context.Context, cluster talos.Cluster, options Options) (*M
 
 	var err error
 
-	clusterAPI.client, err = client.New("")
+	clusterAPI.client, err = client.New(options.ClusterctlConfigPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes sure automation won't overwrite the default config location.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>