### PR TITLE
feat: set servers as dirty by default

### DIFF
--- a/app/metal-controller-manager/internal/server/server.go
+++ b/app/metal-controller-manager/internal/server/server.go
@@ -72,9 +72,6 @@ func (s *server) CreateServer(ctx context.Context, in *api.CreateServerRequest) 
 					Version:      in.GetCpu().GetVersion(),
 				},
 			},
-			Status: metalv1alpha1.ServerStatus{
-				IsClean: true,
-			},
 		}
 
 		if err = c.Create(ctx, obj); err != nil {


### PR DESCRIPTION
It makes more sense to treat every newly added server as dirty so that we can
ensure it goes through the reset process.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
