### PR TITLE
feat: ensure servers are clean

### DIFF
--- a/app/cluster-api-provider-sidero/controllers/metalmachine_controller.go
+++ b/app/cluster-api-provider-sidero/controllers/metalmachine_controller.go
@@ -222,21 +222,6 @@ func (r *MetalMachineReconciler) reconcileDelete(ctx context.Context, metalMachi
 		}
 	}
 
-	mgmtClient, err := metal.NewManagementClient(&serverResource.Spec)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	err = mgmtClient.SetPXE()
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	err = mgmtClient.PowerCycle()
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// Machine is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(metalMachine, infrav1.MachineFinalizer)
 


### PR DESCRIPTION
We need to be certain that servers are clean before they are eligible for
use. This ensures that servers are put through the reset process before they
become ready.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
