### PR TITLE
feat: power down servers !InUse && IsClean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -189,7 +189,7 @@ COPY --from=fmt-build /src /
 # The markdownlint target performs linting on Markdown files.
 #
 FROM node:8.16.1-alpine AS lint-markdown
-RUN npm install -g markdownlint-cli
+RUN npm install -g markdownlint-cli@0.23.2
 RUN npm i sentences-per-line
 WORKDIR /src
 COPY --from=base /src .

--- a/sfyra/pkg/tests/match.go
+++ b/sfyra/pkg/tests/match.go
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metal "github.com/talos-systems/sidero/app/metal-controller-manager/api/v1alpha1"
+)
+
+// TestMatchServersMetalMachines verifies that number of metal machines and servers match.
+func TestMatchServersMetalMachines(ctx context.Context, metalClient client.Client) TestFunc {
+	return func(t *testing.T) {
+		var machines v1alpha3.MachineList
+
+		require.NoError(t, metalClient.List(ctx, &machines))
+
+		var servers metal.ServerList
+
+		require.NoError(t, metalClient.List(ctx, &servers))
+
+		inUseServers := 0
+
+		for _, server := range servers.Items {
+			if server.Status.InUse {
+				inUseServers++
+			}
+		}
+
+		assert.Equal(t, len(machines.Items), inUseServers)
+	}
+}

--- a/sfyra/pkg/tests/tests.go
+++ b/sfyra/pkg/tests/tests.go
@@ -65,6 +65,10 @@ func Run(ctx context.Context, cluster talos.Cluster, vmSet *vm.Set, capiManager 
 			TestManagementCluster(ctx, metalClient, cluster, vmSet, capiManager),
 		},
 		{
+			"TestMatchServersMetalMachines",
+			TestMatchServersMetalMachines(ctx, metalClient),
+		},
+		{
 			"TestServerReset",
 			TestServerReset(ctx, metalClient, vmSet),
 		},


### PR DESCRIPTION
Basically this repeats the power off action which should be done by the
agent image. In case of Sfyra and QEMU VMs, they can't be shutdown via
ACPI, so this code is going to bring Sfyra case closer to the bare metal
case, plus it should handle power off if Server is registered manually
(without agent).

Also mark servers which are `InUse && !IsClean` as `Ready` to assert
that all the servers are ready in the test.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>