### PR TITLE
fix: delete machine instead of metalmachine in reset test

### DIFF
--- a/sfyra/pkg/tests/reset.go
+++ b/sfyra/pkg/tests/reset.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/talos-systems/go-retry/retry"
 	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metal "github.com/talos-systems/sidero/app/cluster-api-provider-sidero/api/v1alpha3"
@@ -40,7 +41,10 @@ func TestServerReset(ctx context.Context, metalClient client.Client, vmSet *vm.S
 
 			serverNamesToCheck = append(serverNamesToCheck, machines.Items[i].Spec.ServerRef.Name)
 
-			err = metalClient.Delete(ctx, &machines.Items[i])
+			ownerMachine, err := util.GetOwnerMachine(ctx, metalClient, machines.Items[i].ObjectMeta)
+			require.NoError(t, err)
+
+			err = metalClient.Delete(ctx, ownerMachine)
 			require.NoError(t, err)
 		}
 


### PR DESCRIPTION
This PR will ensure that the machine is deleted by looking for the owner
of the metalmachine and deleting that instead of the metalmachine so
it'll cascade down.