### PR TITLE
test: add flags for modifying workload cluster images

### DIFF
--- a/sfyra/cmd/sfyra/cmd/test_integration.go
+++ b/sfyra/cmd/sfyra/cmd/test_integration.go
@@ -120,6 +120,7 @@ func init() {
 	testIntegrationCmd.Flags().StringVar(&options.BootstrapTalosVmlinuz, "bootstrap-vmlinuz", options.BootstrapTalosVmlinuz, "Talos kernel image for bootstrap cluster")
 	testIntegrationCmd.Flags().StringVar(&options.BootstrapTalosInitramfs, "bootstrap-initramfs", options.BootstrapTalosInitramfs, "Talos initramfs image for bootstrap cluster")
 	testIntegrationCmd.Flags().StringVar(&options.BootstrapTalosInstaller, "bootstrap-installer", options.BootstrapTalosInstaller, "Talos install image for bootstrap cluster")
+	testIntegrationCmd.Flags().StringVar(&options.TalosInstaller, "installer", options.TalosInstaller, "Talos install image for the cluster")
 	testIntegrationCmd.Flags().StringVar(&options.BootstrapCIDR, "bootstrap-cidr", options.BootstrapCIDR, "bootstrap cluster network CIDR")
 	testIntegrationCmd.Flags().StringVar(&options.ManagementCIDR, "management-cidr", options.ManagementCIDR, "management cluster network CIDR")
 	testIntegrationCmd.Flags().IntVar(&options.ManagementNodes, "management-nodes", options.ManagementNodes, "number of PXE nodes to create for the management rack")


### PR DESCRIPTION
Adds the ability for overriding the initramfs , vmlinuz, and install image.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
