### PR TITLE
test: break serverclass creation into function and allow dummy servers

### DIFF
--- a/sfyra/pkg/capi/metalclient.go
+++ b/sfyra/pkg/capi/metalclient.go
@@ -8,6 +8,7 @@ import (
 	cabpt "github.com/talos-systems/cluster-api-bootstrap-provider-talos/api/v1alpha3"
 	cacpt "github.com/talos-systems/cluster-api-control-plane-provider-talos/api/v1alpha3"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/cluster-api/api/v1alpha3"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,6 +20,10 @@ import (
 // GetMetalClient builds k8s client with schemes required to access all the CAPI/Sidero/Talos components.
 func GetMetalClient(config *rest.Config) (runtimeclient.Client, error) {
 	scheme := runtime.NewScheme()
+
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
 
 	if err := v1alpha3.AddToScheme(scheme); err != nil {
 		return nil, err

--- a/sfyra/pkg/constants/constants.go
+++ b/sfyra/pkg/constants/constants.go
@@ -24,3 +24,6 @@ const MTU = 1500
 
 // BootstrapMaster is a bootstrap cluster master node name.
 const BootstrapMaster = "bootstrap-master"
+
+// SideroAPIVersion is a string we need for creating Sidero resources.
+const SideroAPIVersion = "metal.sidero.dev/v1alpha1"

--- a/sfyra/pkg/tests/environment.go
+++ b/sfyra/pkg/tests/environment.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/talos-systems/sidero/app/metal-controller-manager/api/v1alpha1"
+	"github.com/talos-systems/sidero/sfyra/pkg/constants"
 	"github.com/talos-systems/sidero/sfyra/pkg/talos"
 )
 
@@ -40,7 +41,7 @@ func TestEnvironmentDefault(ctx context.Context, metalClient client.Client, clus
 			cmdline.Append("talos.platform", "metal")
 			cmdline.Append("talos.config", fmt.Sprintf("http://%s:9091/configdata?uuid=", cluster.SideroComponentsIP()))
 
-			environment.APIVersion = "metal.sidero.dev/v1alpha1"
+			environment.APIVersion = constants.SideroAPIVersion
 			environment.Name = environmentName
 			environment.Spec.Kernel.URL = kernelURL
 			environment.Spec.Kernel.SHA512 = "" // TODO: add a test

--- a/sfyra/pkg/tests/server.go
+++ b/sfyra/pkg/tests/server.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/talos-systems/sidero/app/metal-controller-manager/api/v1alpha1"
+	"github.com/talos-systems/sidero/sfyra/pkg/constants"
 	"github.com/talos-systems/sidero/sfyra/pkg/vm"
 )
 
@@ -195,4 +196,25 @@ func TestServersReady(ctx context.Context, metalClient client.Client) TestFunc {
 			return nil
 		}))
 	}
+}
+
+// createDummyServers will submit servers with dummy info that are not tied to QEMU VMs.
+// A number of these, based on "count" will be created.
+// These can be targeted by the spec passed in or the label "dummy-server".
+
+//nolint: deadcode,unused
+func createDummyServer(ctx context.Context, metalClient client.Client, name string, spec v1alpha1.ServerSpec) (v1alpha1.Server, error) {
+	var server v1alpha1.Server
+
+	server.APIVersion = constants.SideroAPIVersion
+	server.Name = name
+	server.Labels = map[string]string{"dummy-server": ""}
+	server.Spec = spec
+
+	err := metalClient.Create(ctx, &server)
+	if err != nil {
+		return server, err
+	}
+
+	return server, nil
 }


### PR DESCRIPTION
This PR moves the serverClass creation into a function that can be
called by multiple tests. Additionally, I added in a function to create
dummy servers that aren't backed by QEMU VMs. Helpful as we develop the
configPatching tests.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>