### PR TITLE
test: apply talos.shutdown=halt kernel argument

### DIFF
--- a/sfyra/pkg/tests/environment.go
+++ b/sfyra/pkg/tests/environment.go
@@ -39,6 +39,7 @@ func TestEnvironmentDefault(ctx context.Context, metalClient client.Client, clus
 			cmdline.Append("reboot", "k")
 			cmdline.Append("panic", "1")
 			cmdline.Append("talos.platform", "metal")
+			cmdline.Append("talos.shutdown", "halt")
 			cmdline.Append("talos.config", fmt.Sprintf("http://%s:9091/configdata?uuid=", cluster.SideroComponentsIP()))
 
 			environment.APIVersion = constants.SideroAPIVersion

--- a/sfyra/pkg/tests/server.go
+++ b/sfyra/pkg/tests/server.go
@@ -125,6 +125,7 @@ func TestServerPatch(ctx context.Context, metalClient client.Client, talosInstal
 				"console=ttyS0",
 				"reboot=k",
 				"panic=1",
+				"talos.shutdown=halt",
 			},
 		}
 		installPatch := configPatchToJSON(t, &installConfig)


### PR DESCRIPTION
This makes `Shutdown()` API halt the QEMU machine instead of rebooting
it.

See https://github.com/talos-systems/talos/pull/2618

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>