### PR TITLE
feat: support server acceptance

### DIFF
--- a/app/cluster-api-provider-sidero/controllers/metalmachine_controller.go
+++ b/app/cluster-api-provider-sidero/controllers/metalmachine_controller.go
@@ -129,6 +129,11 @@ func (r *MetalMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, err
 			return ctrl.Result{}, err
 		}
 
+		// Handles the case of users specifying a server ref directly and pointing to a non-accepted server
+		if !serverResource.Spec.Accepted {
+			return ctrl.Result{}, fmt.Errorf("specified serverref is a non-accepted server")
+		}
+
 		// Fetch the serverclass if it exists so we can ensure the server has it as an owner ref.
 		var serverClassResource *metalv1alpha1.ServerClass
 		if metalMachine.Spec.ServerClassRef != nil {

--- a/app/metal-controller-manager/api/v1alpha1/server_types.go
+++ b/app/metal-controller-manager/api/v1alpha1/server_types.go
@@ -96,6 +96,7 @@ type ServerSpec struct {
 	BMC               *BMC                    `json:"bmc,omitempty"`
 	ManagementAPI     *ManagementAPI          `json:"managementApi,omitempty"`
 	ConfigPatches     []ConfigPatches         `json:"configPatches,omitempty"`
+	Accepted          bool                    `json:"accepted"`
 }
 
 // ServerStatus defines the observed state of Server.
@@ -108,8 +109,9 @@ type ServerStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Accepted",type="boolean",JSONPath=".spec.accepted",description="indicates if the server is accepted"
 // +kubebuilder:printcolumn:name="Allocated",type="boolean",JSONPath=".status.inUse",description="indicates that the server has been allocated"
-// +kubebuilder:printcolumn:name="Clean",type="boolean",JSONPath=".status.isClean,",description="indicates if the server is clean or not"
+// +kubebuilder:printcolumn:name="Clean",type="boolean",JSONPath=".status.isClean",description="indicates if the server is clean or not"
 
 // Server is the Schema for the servers API.
 type Server struct {

--- a/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_servers.yaml
+++ b/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_servers.yaml
@@ -17,12 +17,16 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - description: indicates if the server is accepted
+      jsonPath: .spec.accepted
+      name: Accepted
+      type: boolean
     - description: indicates that the server has been allocated
       jsonPath: .status.inUse
       name: Allocated
       type: boolean
     - description: indicates if the server is clean or not
-      jsonPath: .status.isClean,
+      jsonPath: .status.isClean
       name: Clean
       type: boolean
     name: v1alpha1
@@ -45,6 +49,8 @@ spec:
           spec:
             description: ServerSpec defines the desired state of Server.
             properties:
+              accepted:
+                type: boolean
               bmc:
                 description: BMC defines data about how to talk to the node via ipmitool.
                 properties:
@@ -163,6 +169,8 @@ spec:
                   version:
                     type: string
                 type: object
+            required:
+            - accepted
             type: object
           status:
             description: ServerStatus defines the observed state of Server.

--- a/app/metal-controller-manager/controllers/server_controller.go
+++ b/app/metal-controller-manager/controllers/server_controller.go
@@ -51,6 +51,8 @@ func (r *ServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	switch {
+	case !s.Spec.Accepted:
+		return f(false, false)
 	case s.Status.InUse && s.Status.IsClean:
 		log.Error(fmt.Errorf("server cannot be in use and clean"), "server is in an impossible state", "inUse", s.Status.InUse, "isClean", s.Status.IsClean)
 

--- a/app/metal-controller-manager/controllers/serverclass_controller.go
+++ b/app/metal-controller-manager/controllers/serverclass_controller.go
@@ -44,8 +44,11 @@ func newServerFilter(sl *metalv1alpha1.ServerList) serverFilter {
 		items: make(map[string]metalv1alpha1.Server),
 	}
 
+	// Add all servers to serverclass, but only if they've been accepted first
 	for _, server := range sl.Items {
-		newSF.items[server.Name] = server
+		if server.Spec.Accepted {
+			newSF.items[server.Name] = server
+		}
 	}
 
 	return newSF
@@ -155,7 +158,7 @@ func (r *ServerClassReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		return ctrl.Result{}, fmt.Errorf("unable to get serverclass: %w", err)
 	}
 
-	// Create serverResults struct and seed items with all known servers
+	// Create serverResults struct and seed items with all known, accepted servers
 	results := newServerFilter(sl)
 
 	// Filter servers down based on qualifiers

--- a/app/metal-controller-manager/main.go
+++ b/app/metal-controller-manager/main.go
@@ -46,11 +46,13 @@ func main() {
 		metricsAddr          string
 		apiEndpoint          string
 		enableLeaderElection bool
+		autoAcceptServers    bool
 	)
 
 	flag.StringVar(&apiEndpoint, "api-endpoint", "", "The endpoint used by the discovery environment.")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8081", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&autoAcceptServers, "auto-accept-servers", false, "Add servers as 'accepted' when they register with Sidero API.")
 
 	flag.Parse()
 
@@ -128,7 +130,7 @@ func main() {
 	setupLog.Info("starting internal API server")
 
 	go func() {
-		if err := server.Serve(); err != nil {
+		if err := server.Serve(autoAcceptServers); err != nil {
 			setupLog.Error(err, "unable to start API server", "controller", "Environment")
 			os.Exit(1)
 		}

--- a/sfyra/pkg/capi/capi.go
+++ b/sfyra/pkg/capi/capi.go
@@ -213,17 +213,31 @@ func (clusterAPI *Manager) patch(ctx context.Context) error {
 		return err
 	}
 
-	argsPatched = false
+	apiPatch := false
+	autoAcceptPatch := false
 
 	for _, arg := range deployment.Spec.Template.Spec.Containers[1].Args {
 		if strings.HasPrefix(arg, "--api-endpoint") {
-			argsPatched = true
+			apiPatch = true
+		}
+
+		if strings.HasPrefix(arg, "--auto-accept-servers") {
+			autoAcceptPatch = true
 		}
 	}
 
-	if !argsPatched {
-		deployment.Spec.Template.Spec.Containers[1].Args = append(deployment.Spec.Template.Spec.Containers[1].Args,
-			fmt.Sprintf("--api-endpoint=%s", clusterAPI.cluster.SideroComponentsIP()))
+	if !apiPatch {
+		deployment.Spec.Template.Spec.Containers[1].Args = append(
+			deployment.Spec.Template.Spec.Containers[1].Args,
+			fmt.Sprintf("--api-endpoint=%s", clusterAPI.cluster.SideroComponentsIP()),
+		)
+	}
+
+	if !autoAcceptPatch {
+		deployment.Spec.Template.Spec.Containers[1].Args = append(
+			deployment.Spec.Template.Spec.Containers[1].Args,
+			"--auto-accept-servers=true",
+		)
 	}
 
 	deployment.Spec.Template.Spec.HostNetwork = true

--- a/sfyra/pkg/tests/tests.go
+++ b/sfyra/pkg/tests/tests.go
@@ -49,6 +49,10 @@ func Run(ctx context.Context, cluster talos.Cluster, vmSet *vm.Set, capiManager 
 			TestServerPatch(ctx, metalClient, options.InstallerImage, options.RegistryMirrors),
 		},
 		{
+			"TestServerAcceptance",
+			TestServerAcceptance(ctx, metalClient, vmSet),
+		},
+		{
 			"TestServersReady",
 			TestServersReady(ctx, metalClient),
 		},


### PR DESCRIPTION
This PR adds a bool field to the server spec of `accepted`. This allows
users to adopt a server that has been registered into the sidero
environment. Doing so allows for a server's full lifecycle to be
managed. Users can either edit a server resource to update the accepted
field, or create the server resource manually and supply that with their
spec.

The PR also adds some edge case handling around the sidero API server to
check to make sure a server is accepted before allowing a wipe directive
to be returned, as well as a check for acceptance when trying to use a
serverref in the sidero capi provider.

Will close #122 