### PR TITLE
test: bump talos for halt & healh check fixes

### DIFF
--- a/sfyra/cmd/sfyra/cmd/options.go
+++ b/sfyra/cmd/sfyra/cmd/options.go
@@ -58,7 +58,7 @@ func DefaultOptions() Options {
 
 		TalosKernelURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/vmlinuz-amd64", TalosRelease),
 		TalosInitrdURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/initramfs-amd64.xz", TalosRelease),
-		TalosInstaller: fmt.Sprintf("ghcr.io/talos-systems/installer:%s", TalosRelease),
+		TalosInstaller: fmt.Sprintf("ghcr.io/talos-systems/installer:%s", "v0.7.0-alpha.4-7-gdc6ea74c"), // TODO: revert on new Talos release TalosRelease),
 
 		BootstrapProviders:      []string{"talos"},
 		InfrastructureProviders: []string{"sidero"},


### PR DESCRIPTION
This brings in Talos with support for server halt (instead of poweroff)
and health API fixes.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>