### PR TITLE
test: enable verbose logs for CLI version of loadbalancer

### DIFF
--- a/sfyra/cmd/sfyra/cmd/loadbalancer_create.go
+++ b/sfyra/cmd/sfyra/cmd/loadbalancer_create.go
@@ -64,7 +64,7 @@ var loadbalancerCreateCmd = &cobra.Command{
 				return err
 			}
 
-			lb, err := loadbalancer.NewControlPlane(metalClient, managementSet.BridgeIP(), lbPort, "default", clusterName, managementSet.Nodes())
+			lb, err := loadbalancer.NewControlPlane(metalClient, managementSet.BridgeIP(), lbPort, "default", clusterName, managementSet.Nodes(), true)
 			if err != nil {
 				return err
 			}

--- a/sfyra/pkg/loadbalancer/loadbalancer.go
+++ b/sfyra/pkg/loadbalancer/loadbalancer.go
@@ -48,7 +48,7 @@ type ControlPlane struct {
 }
 
 // NewControlPlane initializes new control plane load balancer.
-func NewControlPlane(client client.Client, address net.IP, port int, clusterNamespace, clusterName string, nodes []provision.NodeInfo) (*ControlPlane, error) {
+func NewControlPlane(client client.Client, address net.IP, port int, clusterNamespace, clusterName string, nodes []provision.NodeInfo, verboseLog bool) (*ControlPlane, error) {
 	cp := ControlPlane{
 		client:           client,
 		clusterNamespace: clusterNamespace,
@@ -69,8 +69,10 @@ func NewControlPlane(client client.Client, address net.IP, port int, clusterName
 
 	cp.endpoint = net.JoinHostPort(address.String(), strconv.Itoa(port))
 
-	// send logs to /dev/null
-	cp.lb.Logger = log.New(ioutil.Discard, "", 0)
+	if !verboseLog {
+		// send logs to /dev/null
+		cp.lb.Logger = log.New(ioutil.Discard, "", 0)
+	}
 
 	// create route without any upstreams yet
 	if err := cp.lb.AddRoute(cp.endpoint, nil); err != nil {

--- a/sfyra/pkg/tests/management_cluster.go
+++ b/sfyra/pkg/tests/management_cluster.go
@@ -55,7 +55,7 @@ func TestManagementCluster(ctx context.Context, metalClient client.Client, clust
 
 		nodeCount := int64(1)
 
-		lb, err := loadbalancer.NewControlPlane(metalClient, vmSet.BridgeIP(), managementClusterLBPort, "default", managementClusterName, vmSet.Nodes())
+		lb, err := loadbalancer.NewControlPlane(metalClient, vmSet.BridgeIP(), managementClusterLBPort, "default", managementClusterName, vmSet.Nodes(), false)
 		require.NoError(t, err)
 
 		defer lb.Close()


### PR DESCRIPTION
The one which runs in the tests is still not verbose as it makes it hard
to see the test output.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>