### PR TITLE
chore: introduce RequeueAfter in metalcluster controller

### DIFF
--- a/app/cluster-api-provider-sidero/controllers/metalcluster_controller.go
+++ b/app/cluster-api-provider-sidero/controllers/metalcluster_controller.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1 "github.com/talos-systems/sidero/app/cluster-api-provider-sidero/api/v1alpha3"
+	"github.com/talos-systems/sidero/app/cluster-api-provider-sidero/pkg/constants"
 )
 
 // MetalClusterReconciler reconciles a MetalCluster object.
@@ -62,7 +63,7 @@ func (r *MetalClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, err
 
 	if cluster == nil {
 		log.Info("Cluster Controller has not yet set OwnerRef")
-		return ctrl.Result{}, fmt.Errorf("no ownerref for cluster %s", metalCluster.ObjectMeta.Name)
+		return ctrl.Result{RequeueAfter: constants.DefaultRequeueAfter}, nil
 	}
 
 	log = log.WithName(fmt.Sprintf("cluster=%s", cluster.Name))

--- a/app/cluster-api-provider-sidero/pkg/constants/constants.go
+++ b/app/cluster-api-provider-sidero/pkg/constants/constants.go
@@ -4,6 +4,9 @@
 
 package constants
 
+import "time"
+
 const (
-	ProviderID = "sidero"
+	ProviderID          = "sidero"
+	DefaultRequeueAfter = time.Second * 20
 )


### PR DESCRIPTION
Looks like there's only a single place where it makes sense to change
`return err` to `RequeueAfter` in `metalcluster_controller`.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>