### PR TITLE
feat: add hostname to the server spec

### DIFF
--- a/app/metal-controller-manager/api/v1alpha1/server_types.go
+++ b/app/metal-controller-manager/api/v1alpha1/server_types.go
@@ -91,6 +91,7 @@ type ConfigPatches struct {
 // ServerSpec defines the desired state of Server.
 type ServerSpec struct {
 	EnvironmentRef    *corev1.ObjectReference `json:"environmentRef,omitempty"`
+	Hostname          string                  `json:"hostname,omitempty"`
 	SystemInformation *SystemInformation      `json:"system,omitempty"`
 	CPU               *CPUInformation         `json:"cpu,omitempty"`
 	BMC               *BMC                    `json:"bmc,omitempty"`
@@ -109,6 +110,7 @@ type ServerStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Hostname",type="string",JSONPath=".spec.hostname",description="server hostname"
 // +kubebuilder:printcolumn:name="Accepted",type="boolean",JSONPath=".spec.accepted",description="indicates if the server is accepted"
 // +kubebuilder:printcolumn:name="Allocated",type="boolean",JSONPath=".status.inUse",description="indicates that the server has been allocated"
 // +kubebuilder:printcolumn:name="Clean",type="boolean",JSONPath=".status.isClean",description="indicates if the server is clean or not"

--- a/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_servers.yaml
+++ b/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_servers.yaml
@@ -17,6 +17,10 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - description: server hostname
+      jsonPath: .spec.hostname
+      name: Hostname
+      type: string
     - description: indicates if the server is accepted
       jsonPath: .spec.accepted
       name: Accepted
@@ -145,6 +149,8 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+              hostname:
+                type: string
               managementApi:
                 description: ManagementAPI defines data about how to talk to the node
                   via simple HTTP API.

--- a/app/metal-controller-manager/internal/server/server.go
+++ b/app/metal-controller-manager/internal/server/server.go
@@ -60,6 +60,7 @@ func (s *server) CreateServer(ctx context.Context, in *api.CreateServerRequest) 
 				Name: in.GetSystemInformation().GetUuid(),
 			},
 			Spec: metalv1alpha1.ServerSpec{
+				Hostname: in.GetHostname(),
 				SystemInformation: &metalv1alpha1.SystemInformation{
 					Manufacturer: in.GetSystemInformation().GetManufacturer(),
 					ProductName:  in.GetSystemInformation().GetProductName(),


### PR DESCRIPTION
Hostname was sent by the agent over gRPC, but not used.

Fixes #117

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>