### PR TITLE
test: bump Talos to 0.7.0-alpha.6 for Sfyra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MODULE := $(shell head -1 go.mod | cut -d' ' -f2)
 
 ARTIFACTS := _out
 PKGS ?= ./...
-TALOS_RELEASE ?= v0.7.0-alpha.4
+TALOS_RELEASE ?= v0.7.0-alpha.6
 
 SFYRA_CLUSTERCTL_CONFIG ?= $(HOME)/.cluster-api/clusterctl.sfyra.yaml
 

--- a/sfyra/cmd/sfyra/cmd/options.go
+++ b/sfyra/cmd/sfyra/cmd/options.go
@@ -58,7 +58,7 @@ func DefaultOptions() Options {
 
 		TalosKernelURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/vmlinuz-amd64", TalosRelease),
 		TalosInitrdURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/initramfs-amd64.xz", TalosRelease),
-		TalosInstaller: fmt.Sprintf("ghcr.io/talos-systems/installer:%s", "v0.7.0-alpha.5"),
+		TalosInstaller: fmt.Sprintf("ghcr.io/talos-systems/installer:%s", TalosRelease),
 
 		BootstrapProviders:      []string{"talos"},
 		InfrastructureProviders: []string{"sidero"},


### PR DESCRIPTION
It should fix test hangs on stopping PXE VMs.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>