### PR TITLE
test: check if servers are reset on acceptance

### DIFF
--- a/sfyra/pkg/capi/capi.go
+++ b/sfyra/pkg/capi/capi.go
@@ -214,15 +214,10 @@ func (clusterAPI *Manager) patch(ctx context.Context) error {
 	}
 
 	apiPatch := false
-	autoAcceptPatch := false
 
 	for _, arg := range deployment.Spec.Template.Spec.Containers[1].Args {
 		if strings.HasPrefix(arg, "--api-endpoint") {
 			apiPatch = true
-		}
-
-		if strings.HasPrefix(arg, "--auto-accept-servers") {
-			autoAcceptPatch = true
 		}
 	}
 
@@ -230,13 +225,6 @@ func (clusterAPI *Manager) patch(ctx context.Context) error {
 		deployment.Spec.Template.Spec.Containers[1].Args = append(
 			deployment.Spec.Template.Spec.Containers[1].Args,
 			fmt.Sprintf("--api-endpoint=%s", clusterAPI.cluster.SideroComponentsIP()),
-		)
-	}
-
-	if !autoAcceptPatch {
-		deployment.Spec.Template.Spec.Containers[1].Args = append(
-			deployment.Spec.Template.Spec.Containers[1].Args,
-			"--auto-accept-servers=true",
 		)
 	}
 

--- a/sfyra/pkg/tests/reset.go
+++ b/sfyra/pkg/tests/reset.go
@@ -48,7 +48,7 @@ func TestServerReset(ctx context.Context, metalClient client.Client, vmSet *vm.S
 			require.NoError(t, err)
 		}
 
-		err = retry.Constant(10*time.Minute, retry.WithUnits(10*time.Second)).Retry(func() error {
+		err = retry.Constant(5*time.Minute, retry.WithUnits(10*time.Second)).Retry(func() error {
 			var servers sidero.ServerList
 
 			err = metalClient.List(ctx, &servers)

--- a/sfyra/pkg/tests/tests.go
+++ b/sfyra/pkg/tests/tests.go
@@ -56,6 +56,10 @@ func Run(ctx context.Context, cluster talos.Cluster, vmSet *vm.Set, capiManager 
 			TestServerAcceptance(ctx, metalClient, vmSet),
 		},
 		{
+			"TestServerResetOnAcceptance",
+			TestServerResetOnAcceptance(ctx, metalClient),
+		},
+		{
 			"TestServersReady",
 			TestServersReady(ctx, metalClient),
 		},


### PR DESCRIPTION
When a server is dirty and not accepted, it should be reset after being accepted.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
