### PR TITLE
fix: use APIReader in server controller to avoid caching issues

### DIFF
--- a/app/metal-controller-manager/controllers/server_controller.go
+++ b/app/metal-controller-manager/controllers/server_controller.go
@@ -26,9 +26,10 @@ import (
 // ServerReconciler reconciles a Server object.
 type ServerReconciler struct {
 	client.Client
-	Log      logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	APIReader client.Reader
+	Log       logr.Logger
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=metal.sidero.dev,resources=servers,verbs=get;list;watch;create;update;patch;delete
@@ -41,7 +42,8 @@ func (r *ServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	s := metalv1alpha1.Server{}
 
-	if err := r.Get(ctx, req.NamespacedName, &s); err != nil {
+	// Refresh the object from the API, as we rely a lot on the Status to be up to date in this controller.
+	if err := r.APIReader.Get(ctx, req.NamespacedName, &s); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/app/metal-controller-manager/main.go
+++ b/app/metal-controller-manager/main.go
@@ -102,10 +102,11 @@ func main() {
 	}
 
 	if err = (&controllers.ServerReconciler{
-		Client:   mgr.GetClient(),
-		Log:      ctrl.Log.WithName("controllers").WithName("Server"),
-		Scheme:   mgr.GetScheme(),
-		Recorder: recorder,
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Log:       ctrl.Log.WithName("controllers").WithName("Server"),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  recorder,
 	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: defaultMaxConcurrentReconciles}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Server")
 		os.Exit(1)


### PR DESCRIPTION
As ServerController is a bit not following the best practices, as it
reconciles based on Status, we need to have it up to date.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>