### PR TITLE
test: enable control plane scale down test

### DIFF
--- a/sfyra/pkg/tests/reconcile.go
+++ b/sfyra/pkg/tests/reconcile.go
@@ -68,7 +68,7 @@ func TestMachineDeploymentReconcile(ctx context.Context, metalClient client.Clie
 		require.NoError(t, err)
 
 		// next, check that replicas get reconciled
-		err = retry.Constant(10*time.Minute, retry.WithUnits(10*time.Second)).Retry(func() error {
+		err = retry.Constant(5*time.Minute, retry.WithUnits(10*time.Second)).Retry(func() error {
 			err = metalClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: machineDeploymentName}, &machineDeployment)
 			if err != nil {
 				return retry.UnexpectedError(err)

--- a/sfyra/pkg/tests/scale.go
+++ b/sfyra/pkg/tests/scale.go
@@ -38,8 +38,6 @@ func TestScaleControlPlaneUp(ctx context.Context, metalClient client.Client, vmS
 // TestScaleControlPlaneDown verifies that the control plane can scale down.
 func TestScaleControlPlaneDown(ctx context.Context, metalClient client.Client, vmSet *vm.Set) TestFunc {
 	return func(t *testing.T) {
-		t.Skip()
-
 		err := scaleControlPlane(ctx, metalClient, 1)
 		require.NoError(t, err)
 
@@ -73,6 +71,10 @@ func TestScaleWorkersDown(ctx context.Context, metalClient client.Client, vmSet 
 func scaleControlPlane(ctx context.Context, metalClient client.Client, replicas int32) error {
 	verify := func(obj runtime.Object) error {
 		o := obj.(*capbt.TalosControlPlane)
+
+		if o.Status.Replicas != replicas {
+			return fmt.Errorf("expected %d replicas, got %d", replicas, o.Status.ReadyReplicas)
+		}
 
 		if o.Status.ReadyReplicas != replicas {
 			return fmt.Errorf("expected %d ready replicas, got %d", replicas, o.Status.ReadyReplicas)


### PR DESCRIPTION
Now that the control plane provider is in better shape, we can start testing.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
