### PR TITLE
chore: add support for control plane port

### DIFF
--- a/sfyra/pkg/tests/server_class.go
+++ b/sfyra/pkg/tests/server_class.go
@@ -150,6 +150,7 @@ func TestServerClassPatch(ctx context.Context, metalClient client.Client, cluste
 		nodeCountWorker := int64(0)
 
 		os.Setenv("CONTROL_PLANE_ENDPOINT", "localhost")
+		os.Setenv("CONTROL_PLANE_PORT", "11111")
 		os.Setenv("CONTROL_PLANE_SERVERCLASS", "dummyservers")
 		os.Setenv("WORKER_SERVERCLASS", "dummyservers")
 		// TODO: make it configurable

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   controlPlaneEndpoint:
     host: ${CONTROL_PLANE_ENDPOINT}
-    port: 6443
+    port: ${CONTROL_PLANE_PORT}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: MetalMachineTemplate


### PR DESCRIPTION
We were missing support for tweaking the load balancer port