### PR TITLE
fix: wipe disk fully in the agent

### DIFF
--- a/app/metal-controller-manager/internal/ipxe/ipxe_server.go
+++ b/app/metal-controller-manager/internal/ipxe/ipxe_server.go
@@ -264,6 +264,7 @@ func newAgentEnvironment() *metalv1alpha1.Environment {
 		"ip=dhcp",
 		"console=tty0",
 		"console=ttyS0",
+		"printk.devkmsg=on",
 		fmt.Sprintf("%s=%s:%s", constants.AgentEndpointArg, apiEndpoint, server.Port),
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pin/tftp v2.1.1-0.20200117065540-2f79be2dba4e+incompatible
 	github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.2.0-alpha.6
 	github.com/talos-systems/cluster-api-control-plane-provider-talos v0.1.0-alpha.8
-	github.com/talos-systems/go-blockdevice v0.1.1-0.20201009184237-ff3a8210be99
+	github.com/talos-systems/go-blockdevice v0.1.1-0.20201022135759-bb8ac5d6a25e
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45
 	github.com/talos-systems/go-retry v0.1.1-0.20200922131245-752f081252cf
 	github.com/talos-systems/go-smbios v0.0.0-20200807005123-80196199691e

--- a/go.sum
+++ b/go.sum
@@ -742,6 +742,8 @@ github.com/talos-systems/crypto v0.2.0 h1:UwT8uhJ0eDlklY0vYwo1+LGoFgiqkPqjQnae6j
 github.com/talos-systems/crypto v0.2.0/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201009184237-ff3a8210be99 h1:2WrfCMZHBgdzM0KnfAhjhWVbhBTzkABeSIQS3/eH7bY=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201009184237-ff3a8210be99/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201022135759-bb8ac5d6a25e h1:M95MiYExtj3ANVqFf4i6zFinqOYhXVzRsgxoUs9Cwc8=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201022135759-bb8ac5d6a25e/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45 h1:FND/LgzFHTBdJBOeZVzdO6B47kxQZvSIzb9AMIXYotg=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=

--- a/sfyra/go.sum
+++ b/sfyra/go.sum
@@ -775,6 +775,8 @@ github.com/talos-systems/crypto v0.2.0 h1:UwT8uhJ0eDlklY0vYwo1+LGoFgiqkPqjQnae6j
 github.com/talos-systems/crypto v0.2.0/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201009184237-ff3a8210be99 h1:2WrfCMZHBgdzM0KnfAhjhWVbhBTzkABeSIQS3/eH7bY=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201009184237-ff3a8210be99/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201022135759-bb8ac5d6a25e h1:M95MiYExtj3ANVqFf4i6zFinqOYhXVzRsgxoUs9Cwc8=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201022135759-bb8ac5d6a25e/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-loadbalancer v0.1.1-0.20201015151439-a4457024d518 h1:3i0Dui7k71VZtfe78h+WfqNA0XO2fRdKlOuIwtpLH7A=
 github.com/talos-systems/go-loadbalancer v0.1.1-0.20201015151439-a4457024d518/go.mod h1:L0uLhCBUQVkdBqtnxqbrw+wzopQyoeluPos8okqdxLo=


### PR DESCRIPTION
This also fixes skipping of CD-ROM devices and other devices we can't
wipe for obvious reasons.

Based on https://github.com/talos-systems/go-blockdevice/pull/7

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>