### PR TITLE
docs: add non-UEFI clause to PXE example

### DIFF
--- a/docs/website/content/docs/v0.1/Guides/first-cluster.md
+++ b/docs/website/content/docs/v0.1/Guides/first-cluster.md
@@ -56,7 +56,13 @@ next-server 192.168.254.2;
 if exists user-class and option user-class = "iPXE" {
   filename "http://192.168.254.2:8081/boot.ipxe";
 } else {
-  filename "ipxe.efi";
+  if substring (option vendor-class-identifier, 15, 5) = "00000" {
+    # BIOS
+    filename "undionly.kpxe";
+  } else {
+    # UEFI
+    filename "ipxe.efi";
+  }
 }
 
 host talos-mgmt-0 {


### PR DESCRIPTION
Revise the example DHCP config to handle BIOS-based PXE clients.

Signed-off-by: Seán C McCord <ulexus@gmail.com>