### PR TITLE
release(v0.1.0-alpha.7): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,37 @@
 
+<a name="v0.1.0-alpha.7"></a>
+## [v0.1.0-alpha.7](https://github.com/talos-systems/talos/compare/v0.1.0-alpha.6...v0.1.0-alpha.7) (2020-10-30)
+
+### Docs
+
+* update site URL and add robots.txt
+* add a metadata section
+* expand server acceptance doc
+* add non-UEFI clause to PXE example
+* add links between concepts and configuration sections
+* add chicken and egg note to overview
+* add support for versioned docs
+
+### Feat
+
+* wipe disks concurrently in the agent
+
+### Fix
+
+* log error with error log
+* wipe disk fully in the agent
+
+
 <a name="v0.1.0-alpha.6"></a>
 ## [v0.1.0-alpha.6](https://github.com/talos-systems/talos/compare/v0.1.0-alpha.5...v0.1.0-alpha.6) (2020-10-21)
 
 ### Feat
 
 * add support for control plane port
+
+### Release
+
+* **v0.1.0-alpha.6:** prepare release
 
 
 <a name="v0.1.0-alpha.5"></a>
@@ -28,7 +55,7 @@
 
 
 <a name="v0.1.0-alpha.4"></a>
-## [v0.1.0-alpha.4](https://github.com/talos-systems/talos/compare/v0.1.0-alpha.3...v0.1.0-alpha.4) (2020-10-15)
+## [v0.1.0-alpha.4](https://github.com/talos-systems/talos/compare/v0.1.0-alpha.3...v0.1.0-alpha.4) (2020-10-19)
 
 ### Chore
 
@@ -51,6 +78,10 @@
 * handle agent errors gracefully
 * use efiboot option
 
+### Release
+
+* **v0.1.0-alpha.4:** prepare release
+
 ### Test
 
 * pull in the new version of go-loadbalancer
@@ -59,9 +90,6 @@
 * bump Talos to 0.7.0-alpha.6 for Sfyra
 * enable verbose logs for CLI version of loadbalancer
 
-### Release
-
-* **v0.1.0-alpha.4:** prepare release
 
 <a name="v0.1.0-alpha.3"></a>
 ## [v0.1.0-alpha.3](https://github.com/talos-systems/talos/compare/v0.1.0-alpha.2...v0.1.0-alpha.3) (2020-10-09)


### PR DESCRIPTION
This is the official v0.1.0-alpha.7 release.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
