### PR TITLE
chore: move to ghcr.io

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,12 +80,12 @@ steps:
     image: autonomy/build-container:latest
     pull: always
     environment:
-      DOCKER_USERNAME:
-        from_secret: docker_username
-      DOCKER_PASSWORD:
-        from_secret: docker_password
+      GHCR_USERNAME:
+        from_secret: ghcr_username
+      GHCR_PASSWORD:
+        from_secret: ghcr_token
     commands:
-      - docker login --username "$${DOCKER_USERNAME}" --password "$${DOCKER_PASSWORD}"
+      - docker login --username "$${GHCR_USERNAME}" --password "$${GHCR_PASSWORD}"
       - make PUSH=true
     when:
       event:
@@ -186,5 +186,3 @@ depends_on:
 ---
 kind: signature
 hmac: 6f5d28e7681196d45877703fce1d8b9ada67955a2cd2205ad01b27d64bd04004
-
-...

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,13 +92,13 @@ FROM base AS build-cluster-api-provider-sidero
 RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux go build -ldflags "-s -w" -o /manager ./app/cluster-api-provider-sidero
 RUN chmod +x /manager
 
-## TODO(rsmitty): make bmc pkg and move to autonomy image
+## TODO(rsmitty): make bmc pkg and move to talos-systems image
 FROM scratch AS cluster-api-provider-sidero
-COPY --from=docker.io/autonomy/ca-certificates:ffdacf0 / /
-COPY --from=docker.io/autonomy/fhs:ffdacf0 / /
-COPY --from=docker.io/autonomy/musl:ffdacf0 / /
-COPY --from=docker.io/autonomy/libressl:ffdacf0 / /
-COPY --from=docker.io/autonomy/ipmitool:ffdacf0 / /
+COPY --from=ghcr.io/talos-systems/ca-certificates:v0.3.0-23-gfe414af / /
+COPY --from=ghcr.io/talos-systems/fhs:v0.3.0-23-gfe414af / /
+COPY --from=ghcr.io/talos-systems/musl:v0.3.0-23-gfe414af / /
+COPY --from=ghcr.io/talos-systems/libressl:v0.3.0-23-gfe414af / /
+COPY --from=ghcr.io/talos-systems/ipmitool:v0.3.0-23-gfe414af / /
 COPY --from=build-cluster-api-provider-sidero /manager /manager
 ENTRYPOINT [ "/manager" ]
 
@@ -116,30 +116,30 @@ RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux go build -ldflags
 RUN chmod +x /agent
 
 FROM scratch AS agent
-COPY --from=docker.io/autonomy/ca-certificates:v0.2.0 / /
-COPY --from=docker.io/autonomy/fhs:v0.2.0 / /
+COPY --from=ghcr.io/talos-systems/ca-certificates:v0.3.0-23-gfe414af / /
+COPY --from=ghcr.io/talos-systems/fhs:v0.3.0-23-gfe414af / /
 COPY --from=agent-build /agent /agent
 ENTRYPOINT [ "/agent" ]
 
-FROM autonomy/tools:v0.2.0 AS initramfs-archive
+FROM ghcr.io/talos-systems/tools:v0.3.0-7-g08245ac AS initramfs-archive
 ENV PATH /toolchain/bin
 RUN [ "/toolchain/bin/mkdir", "/bin" ]
 RUN [ "ln", "-s", "/toolchain/bin/bash", "/bin/sh" ]
 WORKDIR /initramfs
 COPY --from=agent /agent ./init
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0 /lib/firmware/bnx2 ./lib/firmware/bnx2
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0 /lib/firmware/bnx2x ./lib/firmware/bnx2x
+COPY --from=ghcr.io/talos-systems/linux-firmware:v0.3.0-23-gfe414af /lib/firmware/bnx2 ./lib/firmware/bnx2
+COPY --from=ghcr.io/talos-systems/linux-firmware:v0.3.0-23-gfe414af /lib/firmware/bnx2x ./lib/firmware/bnx2x
 RUN set -o pipefail && find . 2>/dev/null | cpio -H newc -o | xz -v -C crc32 -0 -e -T 0 -z >/initramfs.xz
 
 FROM scratch AS initramfs
 COPY --from=initramfs-archive /initramfs.xz /initramfs.xz
 
 FROM scratch AS metal-controller-manager
-COPY --from=docker.io/autonomy/ca-certificates:v0.2.0 / /
-COPY --from=docker.io/autonomy/fhs:v0.2.0 / /
-COPY --from=docker.io/autonomy/musl:ffdacf0 / /
-COPY --from=docker.io/autonomy/libressl:ffdacf0 / /
-COPY --from=docker.io/autonomy/ipmitool:ffdacf0 / /
+COPY --from=ghcr.io/talos-systems/ca-certificates:v0.3.0-23-gfe414af / /
+COPY --from=ghcr.io/talos-systems/fhs:v0.3.0-23-gfe414af / /
+COPY --from=ghcr.io/talos-systems/musl:v0.3.0-23-gfe414af / /
+COPY --from=ghcr.io/talos-systems/libressl:v0.3.0-23-gfe414af / /
+COPY --from=ghcr.io/talos-systems/ipmitool:v0.3.0-23-gfe414af / /
 COPY --from=assets /undionly.kpxe /var/lib/sidero/tftp/undionly.kpxe
 COPY --from=assets /undionly.kpxe /var/lib/sidero/tftp/undionly.kpxe.0
 COPY --from=assets /ipxe.efi /var/lib/sidero/tftp/ipxe.efi
@@ -153,8 +153,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux go build -ldflags
 RUN chmod +x /metal-metadata-server
 
 FROM scratch AS metal-metadata-server
-COPY --from=docker.io/autonomy/ca-certificates:v0.1.0 / /
-COPY --from=docker.io/autonomy/fhs:v0.1.0 / /
+COPY --from=ghcr.io/talos-systems/ca-certificates:v0.3.0-23-gfe414af / /
+COPY --from=ghcr.io/talos-systems/fhs:v0.3.0-23-gfe414af / /
 COPY --from=build-metal-metadata-server /metal-metadata-server /metal-metadata-server
 ENTRYPOINT [ "/metal-metadata-server" ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-REGISTRY ?= docker.io
-USERNAME ?= autonomy
+REGISTRY ?= ghcr.io
+USERNAME ?= talos-systems
 SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)

--- a/docs/website/content/docs/v0.1/Guides/patching.md
+++ b/docs/website/content/docs/v0.1/Guides/patching.md
@@ -24,10 +24,6 @@ configPatches:
     path: /machine/install
     value:
       disk: /dev/sda
-      image: docker.io/autonomy/installer:v0.6.0-beta.0
-      bootloader: true
-      wipe: false
-      force: false
   - op: replace
     path: /cluster/network/cni
     value:

--- a/hack/scripts/integration-test.sh
+++ b/hack/scripts/integration-test.sh
@@ -12,7 +12,7 @@ function build_registry_mirrors {
   if [[ "${CI:-false}" == "true" ]]; then
     REGISTRY_MIRROR_FLAGS=
 
-    for registry in docker.io k8s.gcr.io quay.io gcr.io registry.dev.talos-systems.io; do
+    for registry in docker.io k8s.gcr.io quay.io gcr.io ghcr.io registry.dev.talos-systems.io; do
       local service="registry-${registry//./-}.ci.svc"
       local addr=`python3 -c "import socket; print(socket.gethostbyname('${service}'))"`
 


### PR DESCRIPTION
We need to move to ghcr.io because docker.io is now rate limiting pulls.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
