### PR TITLE
fix: ignore missing partition error

### DIFF
--- a/app/metal-controller-manager/cmd/agent/main.go
+++ b/app/metal-controller-manager/cmd/agent/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -295,7 +296,9 @@ func mainFunc() error {
 					}
 
 					if err := bd.Reset(); err != nil {
-						shutdown(err)
+						if !errors.Is(err, blockdevice.ErrMissingPartitionTable) {
+							shutdown(err)
+						}
 					}
 				} else {
 					method, err := bd.Wipe()


### PR DESCRIPTION
We can't reset a blockdevice if it doesn't have a partition table.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
