### PR TITLE
feat: add power status to servers

### DIFF
--- a/app/metal-controller-manager/api/v1alpha1/server_types.go
+++ b/app/metal-controller-manager/api/v1alpha1/server_types.go
@@ -101,6 +101,7 @@ type ServerStatus struct {
 	IsClean    bool                  `json:"isClean"`
 	Conditions []clusterv1.Condition `json:"conditions,omitempty"`
 	Addresses  []corev1.NodeAddress  `json:"addresses,omitempty"`
+	Power      string                `json:"power,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -110,6 +111,7 @@ type ServerStatus struct {
 // +kubebuilder:printcolumn:name="Accepted",type="boolean",JSONPath=".spec.accepted",description="indicates if the server is accepted"
 // +kubebuilder:printcolumn:name="Allocated",type="boolean",JSONPath=".status.inUse",description="indicates that the server has been allocated"
 // +kubebuilder:printcolumn:name="Clean",type="boolean",JSONPath=".status.isClean",description="indicates if the server is clean or not"
+// +kubebuilder:printcolumn:name="Power",type="string",JSONPath=".status.power",description="display the current power status"
 
 // Server is the Schema for the servers API.
 type Server struct {

--- a/app/metal-controller-manager/pkg/constants/constants.go
+++ b/app/metal-controller-manager/pkg/constants/constants.go
@@ -4,10 +4,14 @@
 
 package constants
 
+import "time"
+
 const (
 	DataDirectory    = "/var/lib/sidero"
 	AgentEndpointArg = "sidero.endpoint"
 
 	KernelAsset = "vmlinuz"
 	InitrdAsset = "initramfs.xz"
+
+	DefaultRequeueAfter = time.Second * 20
 )


### PR DESCRIPTION
It is helpful to know what the server's current power status is. This adds a field
to the server status indicating the current state.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
