### PR TITLE
feat: make "insecure-wipe" default, use new fast wipe method

### DIFF
--- a/app/metal-controller-manager/cmd/agent/main.go
+++ b/app/metal-controller-manager/cmd/agent/main.go
@@ -5,9 +5,7 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -290,16 +288,11 @@ func mainFunc() error {
 				}
 
 				if createResp.GetInsecureWipe() {
-					_, err := bd.Device().WriteAt(bytes.Repeat([]byte{0}, 512), 0)
-					if err != nil {
-						shutdown(err)
+					if err = bd.FastWipe(); err != nil {
+						return fmt.Errorf("failed wiping %q: %w", path, err)
 					}
 
-					if err := bd.Reset(); err != nil {
-						if !errors.Is(err, blockdevice.ErrMissingPartitionTable) {
-							shutdown(err)
-						}
-					}
+					log.Printf("Fast wiped %s", path)
 				} else {
 					method, err := bd.Wipe()
 					if err != nil {

--- a/app/metal-controller-manager/main.go
+++ b/app/metal-controller-manager/main.go
@@ -58,7 +58,7 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8081", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&autoAcceptServers, "auto-accept-servers", false, "Add servers as 'accepted' when they register with Sidero API.")
-	flag.BoolVar(&insecureWipe, "insecure-wipe", false, "Do not wipe the entire disk.")
+	flag.BoolVar(&insecureWipe, "insecure-wipe", true, "Wipe head of the disk only (if false, wipe whole disk).")
 
 	flag.Parse()
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pin/tftp v2.1.1-0.20200117065540-2f79be2dba4e+incompatible
 	github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.2.0-alpha.6
 	github.com/talos-systems/cluster-api-control-plane-provider-talos v0.1.0-alpha.8
-	github.com/talos-systems/go-blockdevice v0.1.1-0.20201022135759-bb8ac5d6a25e
+	github.com/talos-systems/go-blockdevice v0.1.1-0.20201110185542-c4b583363d63
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45
 	github.com/talos-systems/go-retry v0.1.1-0.20200922131245-752f081252cf
 	github.com/talos-systems/go-smbios v0.0.0-20200807005123-80196199691e

--- a/go.sum
+++ b/go.sum
@@ -742,8 +742,8 @@ github.com/talos-systems/crypto v0.2.0 h1:UwT8uhJ0eDlklY0vYwo1+LGoFgiqkPqjQnae6j
 github.com/talos-systems/crypto v0.2.0/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201009184237-ff3a8210be99 h1:2WrfCMZHBgdzM0KnfAhjhWVbhBTzkABeSIQS3/eH7bY=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201009184237-ff3a8210be99/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201022135759-bb8ac5d6a25e h1:M95MiYExtj3ANVqFf4i6zFinqOYhXVzRsgxoUs9Cwc8=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201022135759-bb8ac5d6a25e/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201110185542-c4b583363d63 h1:5ei+XHQX0qRd4j2aOhSJWQYw7nr5vH3Ng7874wLN3cY=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201110185542-c4b583363d63/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45 h1:FND/LgzFHTBdJBOeZVzdO6B47kxQZvSIzb9AMIXYotg=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=

--- a/sfyra/go.sum
+++ b/sfyra/go.sum
@@ -775,8 +775,8 @@ github.com/talos-systems/crypto v0.2.0 h1:UwT8uhJ0eDlklY0vYwo1+LGoFgiqkPqjQnae6j
 github.com/talos-systems/crypto v0.2.0/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201009184237-ff3a8210be99 h1:2WrfCMZHBgdzM0KnfAhjhWVbhBTzkABeSIQS3/eH7bY=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201009184237-ff3a8210be99/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201022135759-bb8ac5d6a25e h1:M95MiYExtj3ANVqFf4i6zFinqOYhXVzRsgxoUs9Cwc8=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201022135759-bb8ac5d6a25e/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201110185542-c4b583363d63 h1:5ei+XHQX0qRd4j2aOhSJWQYw7nr5vH3Ng7874wLN3cY=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201110185542-c4b583363d63/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-loadbalancer v0.1.1-0.20201015151439-a4457024d518 h1:3i0Dui7k71VZtfe78h+WfqNA0XO2fRdKlOuIwtpLH7A=
 github.com/talos-systems/go-loadbalancer v0.1.1-0.20201015151439-a4457024d518/go.mod h1:L0uLhCBUQVkdBqtnxqbrw+wzopQyoeluPos8okqdxLo=


### PR DESCRIPTION
Use new feature of go-blockdevice to implement the "fast wipe" in Sidero
and make it default one: https://github.com/talos-systems/go-blockdevice/pull/13

This new fast wipe is as good as zeroing out with most modern SSDs, but
not as secure, so we can call it "insecure wipe", but make it default to
improve the customer experience.

Fixes #207

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>