### PR TITLE
feat: don't power off the server in discovery agent

### DIFF
--- a/app/metal-controller-manager/cmd/agent/main.go
+++ b/app/metal-controller-manager/cmd/agent/main.go
@@ -171,21 +171,14 @@ func reconcileIPs(ctx context.Context, client api.AgentClient, s *smbios.Smbios,
 func shutdown(err error) {
 	if err != nil {
 		log.Println(err)
-
-		for i := 10; i >= 0; i-- {
-			log.Printf("rebooting in %d seconds\n", i)
-			time.Sleep(1 * time.Second)
-		}
-
-		if unix.Reboot(unix.LINUX_REBOOT_CMD_RESTART) == nil {
-			select {}
-		}
-
-		os.Exit(1)
 	}
 
-	if unix.Reboot(unix.LINUX_REBOOT_CMD_POWER_OFF) == nil {
-		// Wait forever.
+	for i := 10; i >= 0; i-- {
+		log.Printf("rebooting in %d seconds\n", i)
+		time.Sleep(1 * time.Second)
+	}
+
+	if unix.Reboot(unix.LINUX_REBOOT_CMD_RESTART) == nil {
 		select {}
 	}
 


### PR DESCRIPTION
This disables machine power off in discovery agent.

If `Server` resource has `IPMI` information, it will be powered off by
the Sidero controller once it's clean and accepted.

This simplifies the flow for non-IPMI environments, as machines are now
sitting in the boot loop and might start provisioning as soon as
`Server` is allocated.

Fixes #204

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>