### PR TITLE
feat: boot servers via PXE only once by default

### DIFF
--- a/app/cluster-api-provider-sidero/controllers/metalmachine_controller.go
+++ b/app/cluster-api-provider-sidero/controllers/metalmachine_controller.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/utils/pointer"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -275,6 +276,8 @@ func (r *MetalMachineReconciler) reconcileDelete(ctx context.Context, metalMachi
 
 		serverResource.Status.InUse = false
 		serverResource.OwnerReferences = []metav1.OwnerReference{}
+
+		conditions.Delete(serverResource, metalv1alpha1.ConditionPXEBooted)
 
 		if err := patchHelper.Patch(ctx, serverResource); err != nil {
 			return ctrl.Result{}, err

--- a/app/metal-controller-manager/api/v1alpha1/server_types.go
+++ b/app/metal-controller-manager/api/v1alpha1/server_types.go
@@ -89,19 +89,38 @@ type ServerSpec struct {
 	ManagementAPI     *ManagementAPI          `json:"managementApi,omitempty"`
 	ConfigPatches     []ConfigPatches         `json:"configPatches,omitempty"`
 	Accepted          bool                    `json:"accepted"`
+	PXEBootAlways     bool                    `json:"pxeBootAlways,omitempty"`
 }
 
-// ConditionPowerCycle is used to control the powercycle flow.
-const ConditionPowerCycle clusterv1.ConditionType = "PowerCycle"
+const (
+	// ConditionPowerCycle is used to control the powercycle flow.
+	ConditionPowerCycle clusterv1.ConditionType = "PowerCycle"
+	// ConditionPXEBooted is used to record the fact that server got PXE booted.
+	ConditionPXEBooted clusterv1.ConditionType = "PXEBooted"
+)
 
 // ServerStatus defines the observed state of Server.
 type ServerStatus struct {
-	Ready      bool                  `json:"ready"`
-	InUse      bool                  `json:"inUse"`
-	IsClean    bool                  `json:"isClean"`
+	// Ready is true when server is accepted and in use.
+	// +optional
+	Ready bool `json:"ready"`
+
+	// InUse is true when server is assigned to some MetalMachine.
+	// +optional
+	InUse bool `json:"inUse"`
+
+	// IsClean is true when server disks are wiped.
+	// +optional
+	IsClean bool `json:"isClean"`
+
+	// Conditions defines current service state of the Server.
 	Conditions []clusterv1.Condition `json:"conditions,omitempty"`
-	Addresses  []corev1.NodeAddress  `json:"addresses,omitempty"`
-	Power      string                `json:"power,omitempty"`
+
+	// Addresses lists discovered node IPs.
+	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
+
+	// Power is the current power state of the server: "on", "off" or "unknown".
+	Power string `json:"power,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_servers.yaml
+++ b/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_servers.yaml
@@ -164,6 +164,8 @@ spec:
                 required:
                 - endpoint
                 type: object
+              pxeBootAlways:
+                type: boolean
               system:
                 properties:
                   family:
@@ -186,6 +188,7 @@ spec:
             description: ServerStatus defines the observed state of Server.
             properties:
               addresses:
+                description: Addresses lists discovered node IPs.
                 items:
                   description: NodeAddress contains information for the node's address.
                   properties:
@@ -202,6 +205,7 @@ spec:
                   type: object
                 type: array
               conditions:
+                description: Conditions defines current service state of the Server.
                 items:
                   description: Condition defines an observation of a Cluster API resource
                     operational state.
@@ -245,17 +249,18 @@ spec:
                   type: object
                 type: array
               inUse:
+                description: InUse is true when server is assigned to some MetalMachine.
                 type: boolean
               isClean:
+                description: IsClean is true when server disks are wiped.
                 type: boolean
               power:
+                description: 'Power is the current power state of the server: "on",
+                  "off" or "unknown".'
                 type: string
               ready:
+                description: Ready is true when server is accepted and in use.
                 type: boolean
-            required:
-            - inUse
-            - isClean
-            - ready
             type: object
         type: object
     served: true

--- a/app/metal-controller-manager/controllers/serverclass_controller.go
+++ b/app/metal-controller-manager/controllers/serverclass_controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -152,6 +153,11 @@ func (r *ServerClassReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	patchHelper, err := patch.NewHelper(&sc, r)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	sl := &metalv1alpha1.ServerList{}
 
 	if err := r.List(ctx, sl); err != nil {
@@ -181,7 +187,7 @@ func (r *ServerClassReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	sc.Status.ServersAvailable = avail
 	sc.Status.ServersInUse = used
 
-	if err := r.Status().Update(ctx, &sc); err != nil {
+	if err := patchHelper.Patch(ctx, &sc); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/app/metal-controller-manager/internal/server/server.go
+++ b/app/metal-controller-manager/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/tools/reference"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -129,7 +130,9 @@ func (s *server) MarkServerAsWiped(ctx context.Context, in *api.MarkServerAsWipe
 
 	conditions.MarkTrue(obj, metalv1alpha1.ConditionPowerCycle)
 
-	if err := patchHelper.Patch(ctx, obj); err != nil {
+	if err := patchHelper.Patch(ctx, obj, patch.WithOwnedConditions{
+		Conditions: []clusterv1.ConditionType{metalv1alpha1.ConditionPowerCycle},
+	}); err != nil {
 		return nil, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/pensando/goipmi v0.0.0-20200303170213-e858ec1cf0b5
 	github.com/pin/tftp v2.1.1-0.20200117065540-2f79be2dba4e+incompatible
+	github.com/pkg/errors v0.9.1
 	github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.2.0-alpha.6
 	github.com/talos-systems/cluster-api-control-plane-provider-talos v0.1.0-alpha.8
 	github.com/talos-systems/go-blockdevice v0.1.1-0.20201111103554-874213371a3f


### PR DESCRIPTION
Fixes #205

This change makes sure that server gets booted into the environment only
once (unless `.Spec.PXEBootAlways` is set).

If IPMI is used, there're no functional changes, as servers are supposed
to be configured to boot from disk first, and Sidero forces boot from
network as needed.

Without IPMI, now it's possible to set server to boot from network all
the time, and once provisioned, server will boot from disk.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>