### PR TITLE
chore: add info log when no servers in serverclass

### DIFF
--- a/app/cluster-api-provider-sidero/controllers/metalmachine_controller.go
+++ b/app/cluster-api-provider-sidero/controllers/metalmachine_controller.go
@@ -153,6 +153,7 @@ func (r *MetalMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, err
 			serverClassResource, err = r.fetchServerClass(ctx, metalMachine.Spec.ServerClassRef)
 			if err != nil {
 				if errors.Is(err, ErrNoServersInServerClass) {
+					r.Log.Info("No servers available in serverclass", "serverclass", metalMachine.Spec.ServerClassRef.Name)
 					return ctrl.Result{RequeueAfter: constants.DefaultRequeueAfter}, nil
 				}
 


### PR DESCRIPTION
This PR just adds a little output to the user that we couldn't find any
available servers in a serverclass. Helps troubleshoot that they may
have incorrect qualifiers or forgot to accept servers.