### PR TITLE
feat: allow for extra kernel args in agent environment

### DIFF
--- a/app/metal-controller-manager/internal/ipxe/ipxe_server.go
+++ b/app/metal-controller-manager/internal/ipxe/ipxe_server.go
@@ -41,7 +41,10 @@ initrd /env/{{ .Env.Name }}/{{ .InitrdAsset }}
 boot
 `))
 
-var apiEndpoint string
+var (
+	apiEndpoint          string
+	extraAgentKernelArgs []string
+)
 
 func bootFileHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, bootFile)
@@ -140,8 +143,9 @@ func ipxeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func ServeIPXE(endpoint string) error {
+func ServeIPXE(endpoint string, args []string) error {
 	apiEndpoint = endpoint
+	extraAgentKernelArgs = args
 
 	mux := http.NewServeMux()
 
@@ -267,6 +271,8 @@ func newAgentEnvironment() *metalv1alpha1.Environment {
 		"printk.devkmsg=on",
 		fmt.Sprintf("%s=%s:%s", constants.AgentEndpointArg, apiEndpoint, server.Port),
 	}
+
+	args = append(args, extraAgentKernelArgs...)
 
 	env := &metalv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/app/metal-controller-manager/main.go
+++ b/app/metal-controller-manager/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,6 +50,7 @@ func main() {
 	var (
 		metricsAddr          string
 		apiEndpoint          string
+		extraAgentKernelArgs string
 		enableLeaderElection bool
 		autoAcceptServers    bool
 		insecureWipe         bool
@@ -56,6 +58,7 @@ func main() {
 
 	flag.StringVar(&apiEndpoint, "api-endpoint", "", "The endpoint used by the discovery environment.")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8081", "The address the metric endpoint binds to.")
+	flag.StringVar(&extraAgentKernelArgs, "extra-agent-kernel-args", "", "A comma delimited list of key-value pairs to be added to the agent environment kernel parameters.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&autoAcceptServers, "auto-accept-servers", false, "Add servers as 'accepted' when they register with Sidero API.")
 	flag.BoolVar(&insecureWipe, "insecure-wipe", true, "Wipe head of the disk only (if false, wipe whole disk).")
@@ -145,7 +148,9 @@ func main() {
 			}
 		}
 
-		if err := ipxe.ServeIPXE(apiEndpoint); err != nil {
+		args := strings.Split(extraAgentKernelArgs, ",")
+
+		if err := ipxe.ServeIPXE(apiEndpoint, args); err != nil {
 			setupLog.Error(err, "unable to start iPXE server", "controller", "Environment")
 			os.Exit(1)
 		}


### PR DESCRIPTION
This adds a `--extra-agent-kernel-args` flag to the metal controller manager that
allows for adding extra kernel parameters to the agent environment.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
