### PR TITLE
docs: fix typo in asset URLs

### DIFF
--- a/docs/website/content/docs/v0.1/Guides/bootstrapping.md
+++ b/docs/website/content/docs/v0.1/Guides/bootstrapping.md
@@ -185,7 +185,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/latest/download/vmlinuz"
+    url: "https://github.com/talos-systems/talos/releases/latest/download/vmlinuz-amd64"
     sha512: ""
     args:
       - initrd=initramfs.xz
@@ -205,7 +205,7 @@ spec:
       - talos.platform=metal
       - talos.config=http://$PUBLIC_IP:9091/configdata?uuid=
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/latest/download/initramfs.xz"
+    url: "https://github.com/talos-systems/talos/releases/latest/download/initramfs-amd64.xz"
     sha512: ""
 EOF
 ```


### PR DESCRIPTION
We changed the names of these files in 0.7 Talos.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
