### PR TITLE
feat: serve assets from TFTP folder in IPXE HTTP server

### DIFF
--- a/app/metal-controller-manager/internal/ipxe/ipxe_server.go
+++ b/app/metal-controller-manager/internal/ipxe/ipxe_server.go
@@ -159,6 +159,7 @@ func ServeIPXE(endpoint, args string, mgrClient client.Client) error {
 	mux.Handle("/boot.ipxe", logRequest(http.HandlerFunc(bootFileHandler)))
 	mux.Handle("/ipxe", logRequest(http.HandlerFunc(ipxeHandler)))
 	mux.Handle("/env/", logRequest(http.StripPrefix("/env/", http.FileServer(http.Dir("/var/lib/sidero/env")))))
+	mux.Handle("/tftp/", logRequest(http.StripPrefix("/tftp/", http.FileServer(http.Dir("/var/lib/sidero/tftp")))))
 
 	log.Println("Listening...")
 

--- a/docs/website/content/docs/v0.1/Guides/bootstrapping.md
+++ b/docs/website/content/docs/v0.1/Guides/bootstrapping.md
@@ -63,6 +63,9 @@ allow booting;
 next-server 192.168.1.150;
 if exists user-class and option user-class = "iPXE" {
   filename "http://192.168.1.150:8081/boot.ipxe";
+} elsif substring (option vendor-class-identifier, 0, 10) = "HTTPClient" {
+  option vendor-class-identifier "HTTPClient";
+  filename "http://192.168.1.150:8081/tftp/ipxe.efi";
 } else {
   filename "ipxe.efi";
 }

--- a/docs/website/content/docs/v0.1/Guides/first-cluster.md
+++ b/docs/website/content/docs/v0.1/Guides/first-cluster.md
@@ -58,10 +58,20 @@ if exists user-class and option user-class = "iPXE" {
 } else {
   if substring (option vendor-class-identifier, 15, 5) = "00000" {
     # BIOS
-    filename "undionly.kpxe";
+    if substring (option vendor-class-identifier, 0, 10) = "HTTPClient" {
+      option vendor-class-identifier "HTTPClient";
+      filename "http://192.168.254.2:8081/tftp/undionly.kpxe";
+    } else {
+      filename "undionly.kpxe";
+    }
   } else {
     # UEFI
-    filename "ipxe.efi";
+    if substring (option vendor-class-identifier, 0, 10) = "HTTPClient" {
+      option vendor-class-identifier "HTTPClient";
+      filename "http://192.168.254.2:8081/tftp/ipxe.efi";
+    } else {
+      filename "ipxe.efi";
+    }
   }
 }
 


### PR DESCRIPTION
This should allow pulling `ipxe.efi` using http protocol.
Fixes: https://github.com/talos-systems/sidero/issues/241

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>