### PR TITLE
docs: fix typo on Server Classes page

### DIFF
--- a/docs/website/content/docs/v0.1/Configuration/serverclasses.md
+++ b/docs/website/content/docs/v0.1/Configuration/serverclasses.md
@@ -7,7 +7,7 @@ weight: 3
 
 Server classes are a way to group distinct server resources.
 The "qualifiers" key allows the administrator to specify criteria upon which to group these servers.
-There are currently three keys: `cpu`, `systemInformation`, and l`abelSelectors`.
+There are currently three keys: `cpu`, `systemInformation`, and `labelSelectors`.
 Each of these keys accepts a list of entries.
 The top level keys are a "logical AND", while the lists under each key are a "logical OR".
 Qualifiers that are not specified are not evaluated.


### PR DESCRIPTION
`labelSelector` key code block was a bit off.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>