### PR TITLE
fix: prevent server orphaning

### DIFF
--- a/sfyra/pkg/tests/server_class.go
+++ b/sfyra/pkg/tests/server_class.go
@@ -234,6 +234,17 @@ func TestServerClassPatch(ctx context.Context, metalClient client.Client, cluste
 		configProvider, err := configloader.NewFromBytes(metadataBytes)
 		require.NoError(t, err)
 
+		// try deleting dummy server before deleting the cluster
+		// it shouldn't break the cluster
+		require.NoError(t, metalClient.Delete(ctx, &dummyServer))
+
+		time.Sleep(time.Second * 10)
+
+		response := &v1alpha1.Server{}
+
+		require.NoError(t, metalClient.Get(ctx, types.NamespacedName{Name: dummyServer.Name}, response))
+		require.Greater(t, len(response.Finalizers), 0)
+
 		switch configProvider.Version() {
 		case "v1alpha1":
 			config, ok := configProvider.(*talosconfig.Config)


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/sidero/issues/155

Introduce server finalizers, which will block server deletion until
server is deallocated.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>
(cherry picked from commit 6c5fededf83a2aa06126eb6659a9d7d4c223892b)