### PR TITLE
fix: add kubernetes version to cluster template

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -77,6 +77,7 @@ spec:
     matchLabels: null
   template:
     spec:
+      version: ${KUBERNETES_VERSION}
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3


### PR DESCRIPTION
This fixes an issue where the kubelet version for workers could be
subject to being older b/c of constants in the bootstrap provider. This
ensures that the kube version is the same between the control plane and
the worker machine deployment.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>