### PR TITLE
Use LabelSelector for ServerClass filtering.

### DIFF
--- a/app/metal-controller-manager/api/v1alpha1/serverclass_types.go
+++ b/app/metal-controller-manager/api/v1alpha1/serverclass_types.go
@@ -22,6 +22,7 @@ type Qualifiers struct {
 type ServerClassSpec struct {
 	EnvironmentRef *corev1.ObjectReference `json:"environmentRef,omitempty"`
 	Qualifiers     Qualifiers              `json:"qualifiers"`
+	Selector       *metav1.LabelSelector   `json:"selector"`
 	ConfigPatches  []ConfigPatches         `json:"configPatches,omitempty"`
 }
 

--- a/app/metal-controller-manager/api/v1alpha1/zz_generated.deepcopy.go
+++ b/app/metal-controller-manager/api/v1alpha1/zz_generated.deepcopy.go
@@ -10,6 +10,7 @@ package v1alpha1
 
 import (
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/api/v1alpha3"
 )
@@ -417,6 +418,11 @@ func (in *ServerClassSpec) DeepCopyInto(out *ServerClassSpec) {
 		**out = **in
 	}
 	in.Qualifiers.DeepCopyInto(&out.Qualifiers)
+	if in.Selector != nil {
+		in, out := &in.Selector, &out.Selector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ConfigPatches != nil {
 		in, out := &in.ConfigPatches, &out.ConfigPatches
 		*out = make([]ConfigPatches, len(*in))

--- a/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_serverclasses.yaml
+++ b/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_serverclasses.yaml
@@ -91,6 +91,53 @@ spec:
                           type: string
                       type: object
                     type: array
+                  labelSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An
+                      empty label selector matches all objects. A null label selector
+                      matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
                   labelSelectors:
                     items:
                       additionalProperties:

--- a/app/metal-controller-manager/config/samples/metal_v1alpha1_server.yaml
+++ b/app/metal-controller-manager/config/samples/metal_v1alpha1_server.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   # Add fields here
   foo: bar
+  topology.kubernetes.io/region: central
+  environment: dev

--- a/app/metal-controller-manager/config/samples/metal_v1alpha1_serverclass.yaml
+++ b/app/metal-controller-manager/config/samples/metal_v1alpha1_serverclass.yaml
@@ -17,3 +17,16 @@ spec:
     labelSelectors:
       - key1: "val1"
       - key2: "val2"
+    labelSelector:
+      matchLabels:
+        foo: bar
+      matchExpressions:
+        - key: topology.kubernetes.io/region
+          operator: In
+          values:
+            - central
+            - east
+        - key: environment
+          operator: NotIn
+          values:
+            - prod

--- a/app/metal-controller-manager/controllers/serverclass_controller.go
+++ b/app/metal-controller-manager/controllers/serverclass_controller.go
@@ -70,7 +70,10 @@ func (r *ServerClassReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		return ctrl.Result{}, fmt.Errorf("unable to get serverclass: %w", err)
 	}
 
-	results := metalv1alpha1.FilterAcceptedServers(sl.Items, sc.Spec.Qualifiers)
+	results, err := sc.FilterServers(sl.Items)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to filter servers: %w", err)
+	}
 
 	avail := []string{}
 	used := []string{}

--- a/docs/website/content/docs/v0.1/Configuration/serverclasses.md
+++ b/docs/website/content/docs/v0.1/Configuration/serverclasses.md
@@ -5,12 +5,12 @@ weight: 3
 
 # Server Classes
 
-Server classes are a way to group distinct server resources.
-The "qualifiers" key allows the administrator to specify criteria upon which to group these servers.
-There are currently three keys: `cpu`, `systemInformation`, and `labelSelectors`.
-Each of these keys accepts a list of entries.
-The top level keys are a "logical AND", while the lists under each key are a "logical OR".
-Qualifiers that are not specified are not evaluated.
+Server classes are a way to group distinct server resources.  The "qualifiers"
+key allows the administrator to specify criteria upon which to group these
+servers.  There are currently four keys: `cpu`, `systemInformation`,
+`labelSelectors`, and `labelSelector`.  Each of these keys accepts a list of
+entries.  The top level keys are a "logical AND", while the lists under each
+key are a "logical OR".  Qualifiers that are not specified are not evaluated.
 
 An example:
 
@@ -27,7 +27,21 @@ spec:
       - manufacturer: Advanced Micro Devices, Inc.
         version: AMD Ryzen 7 2700X Eight-Core Processor
     labelSelectors:
-      - "my-server-label": "true"
+      - my-server-label: true
+    labelSelector:
+      matchLabels:
+        foo: bar
+      matchExpressions:
+        - key: topology.kubernetes.io/region
+          operator: In
+          values:
+            - central
+            - east
+        - key: environment
+          operator: NotIn
+          values:
+            - prod
 ```
 
-Servers would only be added to the above class if they had _EITHER_ CPU info, _AND_ the label associated with the server resource.
+Servers would only be added to the above class if they had _EITHER_ CPU info,
+_AND_ the label associated with the server resource.


### PR DESCRIPTION
Adds a `LabelSelector` field to the `Qualifiers` struct.

TODO:
- [ ] Depreciate `labelSelectors`?
- [x] Tests
- [ ] Docs

Fixes https://github.com/talos-systems/sidero/issues/282