### PR TITLE
test: drop installer image from the server patch

### DIFF
--- a/sfyra/cmd/sfyra/cmd/options.go
+++ b/sfyra/cmd/sfyra/cmd/options.go
@@ -19,7 +19,6 @@ type Options struct {
 
 	TalosKernelURL string
 	TalosInitrdURL string
-	TalosInstaller string
 
 	ClusterctlConfigPath    string
 	BootstrapProviders      []string
@@ -63,7 +62,6 @@ func DefaultOptions() Options {
 
 		TalosKernelURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/vmlinuz-amd64", TalosRelease),
 		TalosInitrdURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/initramfs-amd64.xz", TalosRelease),
-		TalosInstaller: fmt.Sprintf("ghcr.io/talos-systems/installer:%s", TalosRelease),
 
 		BootstrapProviders:      []string{"talos"},
 		InfrastructureProviders: []string{"sidero"},

--- a/sfyra/cmd/sfyra/cmd/test_integration.go
+++ b/sfyra/cmd/sfyra/cmd/test_integration.go
@@ -101,9 +101,8 @@ var testIntegrationCmd = &cobra.Command{
 			os.Args = append(os.Args[0:1], "-test.v")
 
 			if ok := tests.Run(ctx, bootstrapCluster, managementSet, clusterAPI, tests.Options{
-				KernelURL:      options.TalosKernelURL,
-				InitrdURL:      options.TalosInitrdURL,
-				InstallerImage: options.TalosInstaller,
+				KernelURL: options.TalosKernelURL,
+				InitrdURL: options.TalosInitrdURL,
 
 				RegistryMirrors: options.RegistryMirrors,
 
@@ -125,7 +124,6 @@ func init() {
 	testIntegrationCmd.Flags().StringVar(&options.BootstrapTalosVmlinuz, "bootstrap-vmlinuz", options.BootstrapTalosVmlinuz, "Talos kernel image for bootstrap cluster")
 	testIntegrationCmd.Flags().StringVar(&options.BootstrapTalosInitramfs, "bootstrap-initramfs", options.BootstrapTalosInitramfs, "Talos initramfs image for bootstrap cluster")
 	testIntegrationCmd.Flags().StringVar(&options.BootstrapTalosInstaller, "bootstrap-installer", options.BootstrapTalosInstaller, "Talos install image for bootstrap cluster")
-	testIntegrationCmd.Flags().StringVar(&options.TalosInstaller, "installer", options.TalosInstaller, "Talos install image for the cluster")
 	testIntegrationCmd.Flags().StringVar(&options.BootstrapCIDR, "bootstrap-cidr", options.BootstrapCIDR, "bootstrap cluster network CIDR")
 	testIntegrationCmd.Flags().StringVar(&options.ManagementCIDR, "management-cidr", options.ManagementCIDR, "management cluster network CIDR")
 	testIntegrationCmd.Flags().IntVar(&options.ManagementNodes, "management-nodes", options.ManagementNodes, "number of PXE nodes to create for the management rack")

--- a/sfyra/pkg/tests/server.go
+++ b/sfyra/pkg/tests/server.go
@@ -113,7 +113,7 @@ func TestServerMgmtAPI(ctx context.Context, metalClient client.Client, vmSet *vm
 }
 
 // TestServerPatch patches all the servers for the config.
-func TestServerPatch(ctx context.Context, metalClient client.Client, talosInstaller string, registryMirrors []string) TestFunc {
+func TestServerPatch(ctx context.Context, metalClient client.Client, registryMirrors []string) TestFunc {
 	return func(t *testing.T) {
 		servers := &v1alpha1.ServerList{}
 
@@ -122,7 +122,6 @@ func TestServerPatch(ctx context.Context, metalClient client.Client, talosInstal
 		installConfig := talosconfig.InstallConfig{
 			InstallDisk:       "/dev/vda",
 			InstallBootloader: true,
-			InstallImage:      talosInstaller,
 			InstallExtraKernelArgs: []string{
 				"console=ttyS0",
 				"reboot=k",

--- a/sfyra/pkg/tests/tests.go
+++ b/sfyra/pkg/tests/tests.go
@@ -22,7 +22,6 @@ type TestFunc func(t *testing.T)
 // Options for the test.
 type Options struct {
 	KernelURL, InitrdURL string
-	InstallerImage       string
 
 	RegistryMirrors []string
 
@@ -49,7 +48,7 @@ func Run(ctx context.Context, cluster talos.Cluster, vmSet *vm.Set, capiManager 
 		},
 		{
 			"TestServerPatch",
-			TestServerPatch(ctx, metalClient, options.InstallerImage, options.RegistryMirrors),
+			TestServerPatch(ctx, metalClient, options.RegistryMirrors),
 		},
 		{
 			"TestServerAcceptance",


### PR DESCRIPTION
See https://github.com/talos-systems/cluster-api-bootstrap-provider-talos/issues/58

This makes sure tests are closer to real life: Talos version should be
driven by the `Environment` and installer image defaults.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>