### PR TITLE
fix: break the potential endless reconcile loop of ServerClasses

### DIFF
--- a/app/metal-controller-manager/controllers/serverclass_controller.go
+++ b/app/metal-controller-manager/controllers/serverclass_controller.go
@@ -7,6 +7,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -183,6 +184,10 @@ func (r *ServerClassReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 
 		avail = append(avail, server.Name)
 	}
+
+	// sort lists to avoid spurious updates due to `map` key ordering
+	sort.Strings(avail)
+	sort.Strings(used)
 
 	sc.Status.ServersAvailable = avail
 	sc.Status.ServersInUse = used


### PR DESCRIPTION
As list of server names (UUIDs) was not sorted, and listing and
filtering servers is not deterministic, so on each ServerClass reconcile
ServerClass might be changed which triggers another reconcile and so on
until list of server UUIDs on two reconciles stays the same.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>