### PR TITLE
feat: pull the Sidero configuration as `clusterctl` variables

### DIFF
--- a/app/cluster-api-provider-sidero/config/manager/manager.yaml
+++ b/app/cluster-api-provider-sidero/config/manager/manager.yaml
@@ -18,8 +18,6 @@ spec:
       containers:
         - command:
             - /manager
-          args:
-            - --enable-leader-election
           image: controller:latest
           imagePullPolicy: Always
           name: manager

--- a/app/cluster-api-provider-sidero/main.go
+++ b/app/cluster-api-provider-sidero/main.go
@@ -49,7 +49,7 @@ func main() {
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.IntVar(&webhookPort, "webhook-port", 0, "Webhook Server port, disabled by default. When enabled, the manager will only work as webhook server, no reconcilers are installed.")
 	flag.Parse()

--- a/app/metal-controller-manager/config/manager/manager.yaml
+++ b/app/metal-controller-manager/config/manager/manager.yaml
@@ -54,11 +54,19 @@ spec:
       labels:
         control-plane: metal-controller-manager
     spec:
+      hostNetwork: ${SIDERO_CONTROLLER_MANAGER_HOST_NETWORK:=false}
       containers:
         - command:
             - /manager
           args:
-            - --enable-leader-election=false
+            - --metrics-addr=127.0.0.1:8080
+            - --api-endpoint=${SIDERO_CONTROLLER_MANAGER_API_ENDPOINT:=-}
+            - --extra-agent-kernel-args=${SIDERO_CONTROLLER_MANAGER_EXTRA_AGENT_KERNEL_ARGS:=-}
+            - --auto-accept-servers=${SIDERO_CONTROLLER_MANAGER_AUTO_ACCEPT_SERVERS:=false}
+            - --insecure-wipe=${SIDERO_CONTROLLER_MANAGER_INSECURE_WIPE:=true}
+            - --server-reboot-timeout=${SIDERO_CONTROLLER_MANAGER_SERVER_REBOOT_TIMEOUT:=20m}
+            - --test-power-simulated-explicit-failure-prob=${SIDERO_CONTROLLER_MANAGER_TEST_POWER_EXPLICIT_FAILURE:=0}
+            - --test-power-simulated-silent-failure-prob=${SIDERO_CONTROLLER_MANAGER_TEST_POWER_SILENT_FAILURE:=0}
           image: controller:latest
           imagePullPolicy: Always
           name: manager

--- a/app/metal-controller-manager/config/manager_auth_proxy_patch.yaml
+++ b/app/metal-controller-manager/config/manager_auth_proxy_patch.yaml
@@ -19,7 +19,3 @@ spec:
         ports:
         - containerPort: 8443
           name: https
-      - name: manager
-        args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"

--- a/app/metal-controller-manager/main.go
+++ b/app/metal-controller-manager/main.go
@@ -67,7 +67,7 @@ func main() {
 	flag.StringVar(&apiEndpoint, "api-endpoint", "", "The endpoint used by the discovery environment.")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8081", "The address the metric endpoint binds to.")
 	flag.StringVar(&extraAgentKernelArgs, "extra-agent-kernel-args", "", "A comma delimited list of key-value pairs to be added to the agent environment kernel parameters.")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&autoAcceptServers, "auto-accept-servers", false, "Add servers as 'accepted' when they register with Sidero API.")
 	flag.BoolVar(&insecureWipe, "insecure-wipe", true, "Wipe head of the disk only (if false, wipe whole disk).")
 	flag.DurationVar(&serverRebootTimeout, "server-reboot-timeout", constants.DefaultServerRebootTimeout, "Timeout to wait for the server to restart and start wipe.")
@@ -75,6 +75,15 @@ func main() {
 	flag.Float64Var(&testPowerSimulatedSilentFailureProb, "test-power-simulated-silent-failure-prob", 0, "Test failure simulation setting.")
 
 	flag.Parse()
+
+	// workaround for clusterctl not accepting empty value as default value
+	if extraAgentKernelArgs == "-" {
+		extraAgentKernelArgs = ""
+	}
+
+	if apiEndpoint == "-" {
+		apiEndpoint = ""
+	}
 
 	// only for testing, doesn't affect production, default values simulate no failures
 	api.DefaultDice = api.NewFailureDice(testPowerSimulatedExplicitFailureProb, testPowerSimulatedSilentFailureProb)

--- a/app/metal-metadata-server/config/server/server.yaml
+++ b/app/metal-metadata-server/config/server/server.yaml
@@ -28,12 +28,15 @@ spec:
       labels:
         control-plane: metal-metadata-server
     spec:
+      hostNetwork: ${SIDERO_METADATA_SERVER_HOST_NETWORK:=false}
       containers:
         - image: server:latest
           imagePullPolicy: Always
+          args:
+            - --port=${SIDERO_METADATA_SERVER_PORT:=8080}
           name: server
           ports:
-            - containerPort: 8080
+            - containerPort: ${SIDERO_METADATA_SERVER_PORT:=8080}
               name: http
               protocol: TCP
           resources:

--- a/docs/website/content/docs/v0.3/Getting Started/installation.md
+++ b/docs/website/content/docs/v0.3/Getting Started/installation.md
@@ -5,10 +5,22 @@ weight: 2
 
 # Installation
 
-As of Cluster API version 0.3.9, Sidero is included as a default infrastructure provider in clusterctl.
+As of Cluster API version 0.3.9, Sidero is included as a default infrastructure provider in `clusterctl`.
 
 To install Sidero and the other Talos providers, simply issue:
 
 ```bash
 clusterctl init -b talos -c talos -i sidero
 ```
+
+Sidero supports several variables to configure the installation, these variables can be set either as environment
+variables or as variables in the `clusterctl` configuration:
+
+* `SIDERO_CONTROLLER_MANAGER_HOST_NETWORK` (`false`): run `sidero-controller-manager` on host network
+* `SIDERO_CONTROLLER_MANAGER_API_ENDPOINT` (empty): specifies the IP address controller manager can be reached on, defaults to the node IP
+* `SIDERO_CONTROLLER_MANAGER_EXTRA_AGENT_KERNEL_ARGS` (empty): specifies additional Linux kernel arguments for the Sidero agent (for example, different console settings)
+* `SIDERO_CONTROLLER_MANAGER_AUTO_ACCEPT_SERVERS` (`false`): automatically accept discovered servers, by default `.spec.accepted` should be changed to `true` to accept the server
+* `SIDERO_CONTROLLER_MANAGER_INSECURE_WIPE` (`true`): wipe only the first megabyte of each disk on the server, otherwise wipe the full disk
+* `SIDERO_CONTROLLER_MANAGER_SERVER_REBOOT_TIMEOUT` (`20m`): timeout for the server reboot (how long it might take for the server to be rebooted before Sidero retries an IPMI reboot operation)
+* `SIDERO_METADATA_SERVER_HOST_NETWORK` (`false`): run `sidero-metadta-server` on host network
+* `SIDERO_METADATA_SERVER_PORT` (`8080`): port to use for the metadata server

--- a/docs/website/content/docs/v0.3/Getting Started/resources.md
+++ b/docs/website/content/docs/v0.3/Getting Started/resources.md
@@ -91,21 +91,21 @@ These define a desired deployment environment for Talos, including things like w
 Sidero allows you to define a default environment, as well as other environments that may be specific to a subset of nodes.
 Users can override the environment at the `ServerClass` or `Server` level, if you have requirements for different kernels or kernel parameters.
 
-See the [Environments](/docs/v0.1/configuration/environments/) section of our Configuration docs for examples and more detail.
+See the [Environments](/docs/v0.3/configuration/environments/) section of our Configuration docs for examples and more detail.
 
 #### `Servers`
 
 These represent physical machines as resources in the management plane.
 These `Servers` are created when the physical machine PXE boots and completes a "discovery" process in which it registers with the management plane and provides SMBIOS information such as the CPU manufacturer and version, and memory information.
 
-See the [Servers](/docs/v0.1/configuration/servers/) section of our Configuration docs for examples and more detail.
+See the [Servers](/docs/v0.3/configuration/servers/) section of our Configuration docs for examples and more detail.
 
 #### `ServerClasses`
 
 `ServerClasses` are a grouping of the `Servers` mentioned above, grouped to create classes of servers based on Memory, CPU or other attributes.
 These can be used to compose a bank of `Servers` that are eligible for provisioning.
 
-See the [ServerClasses](/docs/v0.1/configuration/serverclasses/) section of our Configuration docs for examples and more detail.
+See the [ServerClasses](/docs/v0.3/configuration/serverclasses/) section of our Configuration docs for examples and more detail.
 
 ### Metal Metadata Server
 
@@ -116,4 +116,4 @@ While the metadata server does not present unique CRDs within Kubernetes, it's i
 The metadata server may be familiar to you if you have used cloud environments previously.
 Using Talos machine configurations created by the Talos Cluster API bootstrap provider, along with patches specified by editing `Server`/`ServerClass` resources or `TalosConfig`/`TalosControlPlane` resources, metadata is returned to servers who query the metadata server at boot time.
 
-See the [Metadata](/docs/v0.1/configuration/metadata/) section of our Configuration docs for examples and more detail.
+See the [Metadata](/docs/v0.3/configuration/metadata/) section of our Configuration docs for examples and more detail.

--- a/docs/website/content/docs/v0.3/Guides/bootstrapping.md
+++ b/docs/website/content/docs/v0.3/Guides/bootstrapping.md
@@ -123,38 +123,14 @@ As of Cluster API version 0.3.9, Sidero is included as a default infrastructure 
 To install Sidero and the other Talos providers, simply issue:
 
 ```bash
-clusterctl init -b talos -c talos -i sidero
+SIDERO_METADATA_SERVER_HOST_NETWORK=true \
+  SIDERO_METADATA_SERVER_PORT=9091 \
+  SIDERO_CONTROLLER_MANAGER_HOST_NETWORK=true \
+  SIDERO_CONTROLLER_MANAGER_API_ENDPOINT=$PUBLIC_IP \
+  clusterctl init -b talos -c talos -i sidero
 ```
-
-## Patch Components
-
 We will now want to ensure that the Sidero services that got created are publicly accessible across our subnet.
-This will allow the metal machines to speak to these services later.
-
-### Patch the Metadata Server
-
-Update the metadata server component with the following patches:
-
-```bash
-## Update args to use 9091 for port
-kubectl patch deploy -n sidero-system sidero-metadata-server --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args", "value": ["--port=9091"]}]'
-
-## Tweak container port to match
-kubectl patch deploy -n sidero-system sidero-metadata-server --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/ports", "value": [{"containerPort": 9091,"name": "http"}]}]'
-
-## Use host networking
-kubectl patch deploy -n sidero-system sidero-metadata-server --type='json' -p='[{"op": "add", "path": "/spec/template/spec/hostNetwork", "value": true}]'
-```
-
-### Patch the Metal Controller Manager
-
-```bash
-## Update args to specify the api endpoint to use for registration
-kubectl patch deploy -n sidero-system sidero-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1/args", "value": ["--api-endpoint='$PUBLIC_IP'","--metrics-addr=127.0.0.1:8080","--enable-leader-election"]}]'
-
-## Use host networking
-kubectl patch deploy -n sidero-system sidero-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/hostNetwork", "value": true}]'
-```
+These variables above will allow the metal machines to speak to these services later.
 
 ## Register the Servers
 
@@ -179,7 +155,7 @@ Servers can be accepted by issuing a patch command like:
 kubectl patch server 00000000-0000-0000-0000-d05099d33360 --type='json' -p='[{"op": "replace", "path": "/spec/accepted", "value": true}]'
 ```
 
-For more information on server acceptance, see the [server docs](/docs/v0.1/configuration/servers).
+For more information on server acceptance, see the [server docs](/docs/v0.3/configuration/servers).
 
 ## Create the Default Environment
 
@@ -227,7 +203,7 @@ EOF
 We must now create a server class to wrap our servers we registered.
 This is necessary for using the Talos control plane provider for Cluster API.
 The qualifiers needed for your server class will differ based on the data provided by your registration flow.
-See the [server class docs](/docs/v0.1/configuration/serverclasses) for more info on how these work.
+See the [server class docs](/docs/v0.3/configuration/serverclasses) for more info on how these work.
 
 Here is an example of how to apply the server class once you have the proper info:
 
@@ -250,7 +226,7 @@ In order to fetch hardware information, you can use
 kubectl get server -o yaml
 ```
 
-Note that for bare-metal setup, you would need to specify an installation disk. See the [Installation Disk](/docs/v0.1/configuration/servers/#installation-disk)
+Note that for bare-metal setup, you would need to specify an installation disk. See the [Installation Disk](/docs/v0.3/configuration/servers/#installation-disk)
 
 Once created, you should see the servers that make up your server class appear as "available":
 

--- a/docs/website/content/docs/v0.3/Guides/first-cluster.md
+++ b/docs/website/content/docs/v0.3/Guides/first-cluster.md
@@ -17,7 +17,7 @@ There will be two main steps in this guide: reconfiguring the Sidero components 
 In this guide, we will convert the metadata service to a NodePort service and the other services to use host networking.
 This is also necessary because some protocols like TFTP don't allow for port configuration.
 Along with some nodeSelectors and a scale up of the metal controller manager deployment, creating the services this way allows for the creation of DNS names that point to all management plane nodes and provide an HA experience if desired.
-It should also be noted, however, that there are many options for acheiving this functionality.
+It should also be noted, however, that there are many options for achieving this functionality.
 Users can look into projects like MetalLB or KubeRouter with BGP and ECMP if they desire something else.
 
 Metal Controller Manager:
@@ -104,7 +104,7 @@ Servers can be accepted by issuing a patch command like:
 kubectl patch server 00000000-0000-0000-0000-d05099d33360 --type='json' -p='[{"op": "replace", "path": "/spec/accepted", "value": true}]'
 ```
 
-For more information on server acceptance, see the [server docs](/docs/v0.1/configuration/servers).
+For more information on server acceptance, see the [server docs](/docs/v0.3/configuration/servers).
 
 ## Create the Cluster
 


### PR DESCRIPTION
This allows to skip patching any components on initial install, and if
the variables are preserved, settings are preserved across upgrades.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>