### PR TITLE
fix: remove erroneous wg.Add in environment controller

### DIFF
--- a/app/metal-controller-manager/controllers/environment_controller.go
+++ b/app/metal-controller-manager/controllers/environment_controller.go
@@ -161,7 +161,6 @@ func (r *EnvironmentReconciler) reconcile(req ctrl.Request) (ctrl.Result, error)
 		// At this point the file exists, but the URL for the file has changed. We
 		// need to update the file using the new URL.
 
-		wg.Add(1)
 		l.Info("updating asset", "url", assetTask.Asset.URL)
 		saveAsset(file)
 	}


### PR DESCRIPTION
With that extra `wg.Add` controller was hanging forever on `wg.Wait()`
every time URL was changed.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>