### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+---
+
+# See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    commit-message:
+      prefix: "chore:"
+    open-pull-requests-limit: 10
+    rebase-strategy: disabled
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "UTC"
+
+  - package-ecosystem: "gomod"
+    directory: "/sfyra"
+    commit-message:
+      prefix: "chore:"
+    open-pull-requests-limit: 10
+    rebase-strategy: disabled
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "UTC"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    commit-message:
+      prefix: "chore:"
+    open-pull-requests-limit: 10
+    rebase-strategy: disabled
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "UTC"
+
+# no website for now

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+.env
+.envrc
+bin
 _out
+.vscode
+*.code-workspace


### PR DESCRIPTION
Just like we do in Talos.

After this PR is merged, dependabot should be enabled at https://github.com/talos-systems/sidero/settings/security_analysis