### PR TITLE
feat: embed iPXE script into the iPXE binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TEST_PKGS ?= ./...
 TALOS_RELEASE ?= v0.9.3
 
 TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0
-PKGS ?= v0.5.0
+PKGS ?= v0.5.0-8-gb0d9cd2
 
 SFYRA_CLUSTERCTL_CONFIG ?= $(HOME)/.cluster-api/clusterctl.sfyra.yaml
 

--- a/app/metal-controller-manager/internal/ipxe/patch.go
+++ b/app/metal-controller-manager/internal/ipxe/patch.go
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ipxe
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// PatchBinaries patches iPXE binaries on the fly with the new embedded script.
+//
+// This relies on special build in `pkgs/ipxe` where a placeholder iPXE script is embedded.
+// EFI iPXE binaries are uncompressed, so these are patched directly.
+// BIOS amd64 undionly.pxe is compressed, so we instead patch uncompressed version and compress it back using zbin.
+// (zbin is built with iPXE).
+func PatchBinaries(script []byte) error {
+	if err := patchScript("/var/lib/sidero/ipxe/amd64/ipxe.efi", "/var/lib/sidero/tftp/ipxe.efi", script); err != nil {
+		return err
+	}
+
+	if err := patchScript("/var/lib/sidero/ipxe/arm64/ipxe.efi", "/var/lib/sidero/tftp/ipxe-arm64.efi", script); err != nil {
+		return err
+	}
+
+	if err := patchScript("/var/lib/sidero/ipxe/amd64/kpxe/undionly.kpxe.bin", "/var/lib/sidero/ipxe/amd64/kpxe/undionly.kpxe.bin.patched", script); err != nil {
+		return err
+	}
+
+	if err := compressKPXE("/var/lib/sidero/ipxe/amd64/kpxe/undionly.kpxe.bin.patched", "/var/lib/sidero/ipxe/amd64/kpxe/undionly.kpxe.zinfo", "/var/lib/sidero/tftp/undionly.kpxe"); err != nil {
+		return err
+	}
+
+	if err := compressKPXE("/var/lib/sidero/ipxe/amd64/kpxe/undionly.kpxe.bin.patched", "/var/lib/sidero/ipxe/amd64/kpxe/undionly.kpxe.zinfo", "/var/lib/sidero/tftp/undionly.kpxe.0"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var (
+	placeholderStart = []byte("# *PLACEHOLDER START*")
+	placeholderEnd   = []byte("# *PLACEHOLDER END*")
+)
+
+func patchScript(source, destination string, script []byte) error {
+	contents, err := os.ReadFile(source)
+	if err != nil {
+		return err
+	}
+
+	start := bytes.Index(contents, placeholderStart)
+	if start == -1 {
+		return fmt.Errorf("placeholder start not found in %q", source)
+	}
+
+	end := bytes.Index(contents, placeholderEnd)
+	if end == -1 {
+		return fmt.Errorf("placeholder end not found in %q", source)
+	}
+
+	if end < start {
+		return fmt.Errorf("placeholder end before start")
+	}
+
+	end += len(placeholderEnd)
+
+	length := end - start
+
+	if len(script) > length {
+		return fmt.Errorf("script size %d is larger than placeholder space %d", len(script), length)
+	}
+
+	script = append(script, bytes.Repeat([]byte{'\n'}, length-len(script))...)
+
+	copy(contents[start:end], script)
+
+	if err = os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return err
+	}
+
+	return os.WriteFile(destination, contents, 0o644)
+}
+
+// compressPXE is equivalent to: ./util/zbin bin/undionly.kpxe.bin bin/undionly.kpxe.zinfo > bin/undionly.kpxe.zbin.
+func compressKPXE(binFile, infoFile, outFile string) error {
+	out, err := os.Create(outFile)
+	if err != nil {
+		return err
+	}
+
+	defer out.Close()
+
+	cmd := exec.Command("/bin/zbin", binFile, infoFile)
+	cmd.Stdout = out
+
+	return cmd.Run()
+}

--- a/docs/website/content/docs/v0.3/Guides/bootstrapping.md
+++ b/docs/website/content/docs/v0.3/Guides/bootstrapping.md
@@ -61,14 +61,7 @@ allow bootp;
 allow booting;
 
 next-server 192.168.1.150;
-if exists user-class and option user-class = "iPXE" {
-  filename "http://192.168.1.150:8081/boot.ipxe";
-} elsif substring (option vendor-class-identifier, 0, 10) = "HTTPClient" {
-  option vendor-class-identifier "HTTPClient";
-  filename "http://192.168.1.150:8081/tftp/ipxe.efi";
-} else {
-  filename "ipxe.efi";
-}
+filename "ipxe.efi";
 
 host talos-mgmt-0 {
     fixed-address 192.168.254.2;

--- a/docs/website/content/docs/v0.3/Guides/first-cluster.md
+++ b/docs/website/content/docs/v0.3/Guides/first-cluster.md
@@ -81,6 +81,12 @@ host talos-mgmt-0 {
 }
 ```
 
+There are multiple ways to boot the via iPXE:
+
+* if the node has built-in iPXE, direct URL to the iPXE script can be used: `http://192.168.254.2:8081/boot.ipxe`.
+* depending on the boot mode (BIOS or UEFI), either `ipxe.efi` or `undionly.kpxe` can be used (these images contain embedded iPXE scripts).
+* iPXE binaries can be delivered either over TFTP or HTTP (HTTP support depends on node firmware).
+
 ## Register the Servers
 
 At this point, any servers on the same network as Sidero should PXE boot using the Sidero PXE service.

--- a/sfyra/pkg/bootstrap/cluster.go
+++ b/sfyra/pkg/bootstrap/cluster.go
@@ -134,8 +134,6 @@ func (cluster *Cluster) findExisting(ctx context.Context) error {
 		return err
 	}
 
-	config.Context = cluster.options.Name
-
 	_, cidr, err := net.ParseCIDR(cluster.options.CIDR)
 	if err != nil {
 		return err

--- a/sfyra/pkg/vm/set.go
+++ b/sfyra/pkg/vm/set.go
@@ -161,7 +161,7 @@ func (set *Set) create(ctx context.Context) error {
 				},
 				PXEBooted:           true,
 				TFTPServer:          set.options.BootSource.String(),
-				IPXEBootFilename:    fmt.Sprintf("http://%s:8081/boot.ipxe", set.options.BootSource),
+				IPXEBootFilename:    "undionly.kpxe",
 				SkipInjectingConfig: true,
 			})
 	}


### PR DESCRIPTION
Fixes #227

See also https://github.com/talos-systems/pkgs/pull/267

The rough idea is that iPXE binaries we're building contain placeholder
script which is replaced on the fly with the actual script which depends
on Sidero API endpoint. Patching is a bit tricky for `undionly.kpxe`, as
it is compressed, so we patch uncompressed version and compress the
final asset after that.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>