### PR TITLE
chore: fix `make help` command

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -204,6 +204,6 @@ depends_on:
   - default
 ---
 kind: signature
-hmac: 201f40ae8975352489a50a2bda0c9480b3aa191772a1501a62dca5decd1f2aa4
+hmac: ed1ab31849fd8548308a8714cfa7f9db77519ddf9d8616b3d8741ceeebb1dcbd
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ The build process makes use of features not currently supported by the default
 builder instance (docker driver). To create a compatible builder instance, run:
 
 ```
-docker buildx create --driver docker-container --name local --buildkitd-flags --use
+docker buildx create --driver docker-container --name local --use
 ```
 
 If you already have a compatible builder instance, you may use that instead.


### PR DESCRIPTION
The old output was interpreted as

--buildkitd-flags '--use'

that did not work.

Also fix .drone.yml signature.

Signed-off-by: Alexey Palazhchenko <alexey.palazhchenko@gmail.com>