### PR TITLE
docs: fix install disk name in the examples

### DIFF
--- a/docs/website/content/docs/v0.1/Configuration/servers.md
+++ b/docs/website/content/docs/v0.1/Configuration/servers.md
@@ -50,7 +50,7 @@ spec:
   configPatches:
     - op: replace
       path: /machine/install/disk
-      value: /dev/sda1
+      value: /dev/sda
 ```
 
 The install disk patch can also be set on the `ServerClass`:
@@ -63,7 +63,7 @@ spec:
   configPatches:
     - op: replace
       path: /machine/install/disk
-      value: /dev/sda1
+      value: /dev/sda
 ```
 
 ## Server Acceptance

--- a/docs/website/content/docs/v0.2/Configuration/servers.md
+++ b/docs/website/content/docs/v0.2/Configuration/servers.md
@@ -50,7 +50,7 @@ spec:
   configPatches:
     - op: replace
       path: /machine/install/disk
-      value: /dev/sda1
+      value: /dev/sda
 ```
 
 The install disk patch can also be set on the `ServerClass`:
@@ -63,7 +63,7 @@ spec:
   configPatches:
     - op: replace
       path: /machine/install/disk
-      value: /dev/sda1
+      value: /dev/sda
 ```
 
 ## Server Acceptance

--- a/docs/website/content/docs/v0.3/Configuration/servers.md
+++ b/docs/website/content/docs/v0.3/Configuration/servers.md
@@ -50,7 +50,7 @@ spec:
   configPatches:
     - op: replace
       path: /machine/install/disk
-      value: /dev/sda1
+      value: /dev/sda
 ```
 
 The install disk patch can also be set on the `ServerClass`:
@@ -63,7 +63,7 @@ spec:
   configPatches:
     - op: replace
       path: /machine/install/disk
-      value: /dev/sda1
+      value: /dev/sda
 ```
 
 ## Server Acceptance


### PR DESCRIPTION
We should always use raw devices.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>