### PR TITLE
test: fix the Environment args to support UEFI boot

### DIFF
--- a/docs/website/content/docs/v0.3/Guides/bootstrapping.md
+++ b/docs/website/content/docs/v0.3/Guides/bootstrapping.md
@@ -61,7 +61,7 @@ allow bootp;
 allow booting;
 
 next-server 192.168.1.150;
-filename "ipxe.efi";
+filename "ipxe.efi"; # use "undionly.kpxe" for BIOS netboot or "ipxe.efi" for UEFI netboot
 
 host talos-mgmt-0 {
     fixed-address 192.168.254.2;

--- a/sfyra/pkg/tests/environment.go
+++ b/sfyra/pkg/tests/environment.go
@@ -44,6 +44,7 @@ func TestEnvironmentDefault(ctx context.Context, metalClient client.Client, clus
 			cmdline.Append("talos.platform", "metal")
 			cmdline.Append("talos.shutdown", "halt")
 			cmdline.Append("talos.config", fmt.Sprintf("http://%s:9091/configdata?uuid=", cluster.SideroComponentsIP()))
+			cmdline.Append("initrd", "initramfs.xz")
 
 			environment.APIVersion = constants.SideroAPIVersion
 			environment.Name = environmentName


### PR DESCRIPTION
This fixes part of the UEFI boot in Sfyra. UEFI boot is still buggy as
UEFI doesn't quite support forcing boot from the network via QEMU args,
but this brings it one step closer.

Also clarify in the docs that iPXE filename depends on the node
architecture.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>