### PR TITLE
fix: back down resource requests

### DIFF
--- a/app/cluster-api-provider-sidero/config/manager/manager.yaml
+++ b/app/cluster-api-provider-sidero/config/manager/manager.yaml
@@ -26,6 +26,6 @@ spec:
               cpu: 1000m
               memory: 512Mi
             requests:
-              cpu: 500m
-              memory: 256Mi
+              cpu: 100m
+              memory: 128Mi
       terminationGracePeriodSeconds: 10

--- a/app/metal-controller-manager/config/manager/manager.yaml
+++ b/app/metal-controller-manager/config/manager/manager.yaml
@@ -91,6 +91,6 @@ spec:
               cpu: 1000m
               memory: 512Mi
             requests:
-              cpu: 500m
-              memory: 256Mi
+              cpu: 100m
+              memory: 128Mi
       terminationGracePeriodSeconds: 10

--- a/app/metal-metadata-server/config/server/server.yaml
+++ b/app/metal-metadata-server/config/server/server.yaml
@@ -44,6 +44,6 @@ spec:
               cpu: 500m
               memory: 512Mi
             requests:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 100m
+              memory: 128Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This fixes an issue where sidero can't be installed on a 2 CPU/2GB RAM
node. Backing down the requests so that the pods can get scheduled, but
still keeping the limits high.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
