### PR TITLE
fix: check all labels in a serverclass labelselector

### DIFF
--- a/app/metal-controller-manager/api/v1alpha1/serverclass_filter_test.go
+++ b/app/metal-controller-manager/api/v1alpha1/serverclass_filter_test.go
@@ -17,6 +17,12 @@ func TestFilterAcceptedServers(t *testing.T) {
 	t.Parallel()
 
 	atom := metalv1alpha1.Server{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"common-label": "true",
+				"zone":         "central",
+			},
+		},
 		Spec: metalv1alpha1.ServerSpec{
 			Accepted: true,
 			CPU: &metalv1alpha1.CPUInformation{
@@ -28,7 +34,8 @@ func TestFilterAcceptedServers(t *testing.T) {
 	ryzen := metalv1alpha1.Server{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"my-server-label": "true",
+				"common-label": "true",
+				"zone":         "east",
 			},
 		},
 		Spec: metalv1alpha1.ServerSpec{
@@ -45,7 +52,7 @@ func TestFilterAcceptedServers(t *testing.T) {
 	notAccepted := metalv1alpha1.Server{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"my-server-label": "true",
+				"common-label": "true",
 			},
 		},
 		Spec: metalv1alpha1.ServerSpec{
@@ -90,11 +97,35 @@ func TestFilterAcceptedServers(t *testing.T) {
 			q: metalv1alpha1.Qualifiers{
 				LabelSelectors: []map[string]string{
 					{
-						"my-server-label": "true",
+						"common-label": "true",
 					},
 				},
 			},
-			expected: []metalv1alpha1.Server{ryzen},
+			expected: []metalv1alpha1.Server{atom, ryzen},
+		},
+		"with multiple labels - single selector": {
+			q: metalv1alpha1.Qualifiers{
+				LabelSelectors: []map[string]string{
+					{
+						"common-label": "true",
+						"zone":         "central",
+					},
+				},
+			},
+			expected: []metalv1alpha1.Server{atom},
+		},
+		"with multiple labels - multiple selectors": {
+			q: metalv1alpha1.Qualifiers{
+				LabelSelectors: []map[string]string{
+					{
+						"common-label": "true",
+					},
+					{
+						"zone": "central",
+					},
+				},
+			},
+			expected: []metalv1alpha1.Server{atom, ryzen},
 		},
 		metalv1alpha1.ServerClassAny: {
 			expected: []metalv1alpha1.Server{atom, ryzen},


### PR DESCRIPTION
We can provide zero or more labelSelectors in a ServerClass to
filter Servers. Each labelSelector is a map of labels. This fixes
a bug where if only one label in one labelSelector matches, all
servers with that label would match.

https://github.com/talos-systems/sidero/issues/288