### PR TITLE
chore: cut bootstrap server resources in Sfyra

### DIFF
--- a/sfyra/cmd/sfyra/cmd/options.go
+++ b/sfyra/cmd/sfyra/cmd/options.go
@@ -71,8 +71,8 @@ func DefaultOptions() Options {
 		ManagementSetName: "sfyra-management",
 		ManagementNodes:   4,
 
-		BootstrapMemMB:  4096,
-		BootstrapCPUs:   5,
+		BootstrapMemMB:  3072,
+		BootstrapCPUs:   3,
 		BootstrapDiskGB: 6,
 
 		ManagementMemMB:  2048,


### PR DESCRIPTION
After we scaled down requests fro our componenets, we can provision
smaller bootstrap node where CAPI gets installed.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>