### PR TITLE
docs: clarify docs around endpoints and metadata server

### DIFF
--- a/docs/website/content/docs/v0.3/Configuration/environments.md
+++ b/docs/website/content/docs/v0.3/Configuration/environments.md
@@ -27,7 +27,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.8.1/vmlinuz-amd64"
+    url: "https://github.com/talos-systems/talos/releases/download/v0.10.2/vmlinuz-amd64"
     sha512: ""
     args:
       - init_on_alloc=1
@@ -47,7 +47,7 @@ spec:
       - talos.platform=metal
       - talos.config=http://$PUBLIC_IP:8081/configdata?uuid=
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.8.1/initramfs-amd64.xz"
+    url: "https://github.com/talos-systems/talos/releases/download/v0.10.2/initramfs-amd64.xz"
     sha512: ""
 ```
 

--- a/docs/website/content/docs/v0.3/Configuration/metadata.md
+++ b/docs/website/content/docs/v0.3/Configuration/metadata.md
@@ -7,7 +7,7 @@ weight: 4
 
 The Metadata server manages the Machine metadata.
 In terms of Talos (the OS on which the Kubernetes cluster is formed), this is the
-"[machine config](https://www.talos.dev/docs/v0.8/reference/configuration/)",
+"[machine config](https://www.talos.dev/docs/v0.10/reference/configuration/)",
 which is used during the automated installation.
 
 ## Talos Machine Configuration

--- a/docs/website/content/docs/v0.3/Getting Started/installation.md
+++ b/docs/website/content/docs/v0.3/Getting Started/installation.md
@@ -24,3 +24,13 @@ variables or as variables in the `clusterctl` configuration:
 * `SIDERO_CONTROLLER_MANAGER_AUTO_BMC_SETUP` (`true`): automatically attempt to configure the BMC with a `sidero` user that will be used for all IPMI tasks.
 * `SIDERO_CONTROLLER_MANAGER_INSECURE_WIPE` (`true`): wipe only the first megabyte of each disk on the server, otherwise wipe the full disk
 * `SIDERO_CONTROLLER_MANAGER_SERVER_REBOOT_TIMEOUT` (`20m`): timeout for the server reboot (how long it might take for the server to be rebooted before Sidero retries an IPMI reboot operation)
+
+Sidero provides two endpoints which should be made available to the infrastructure:
+
+* TCP port 8081 which provides combined iPXE, metadata and gRPC service (external endpoint should be passed to Sidero as `SIDERO_CONTROLLER_MANAGER_API_ENDPOINT` and  `SIDERO_CONTROLLER_MANAGER_API_PORT`)
+* UDP port 69 for the TFTP service (DHCP server should point the nodes to PXE boot from that IP)
+
+These endpoints could be exposed to the infrastructure using different strategies:
+
+* running `sidero-controller-manager` on the host network.
+* using Kubernetes load balancers (e.g. MetalLB), ingress controllers, etc.

--- a/docs/website/content/docs/v0.3/Getting Started/introduction.md
+++ b/docs/website/content/docs/v0.3/Getting Started/introduction.md
@@ -12,10 +12,9 @@ Sidero is also a subproject of Talos Systems' [Arges](https://github.com/talos-s
 
 ## Overview
 
-Sidero is made currently made up of three components:
+Sidero is currently made up of two components:
 
-- Metal Metadata Server: Provides a Cluster API (CAPI)-aware metadata server
-- Metal Controller Manager: Provides custom resources and controllers for managing the lifecycle of metal machines
+- Metal Controller Manager: Provides custom resources and controllers for managing the lifecycle of metal machines, iPXE server, metadata service, and gRPC API service
 - Cluster API Provider Sidero (CAPS): A Cluster API infrastructure provider that makes use of the pieces above to spin up Kubernetes clusters
 
 Sidero also needs these co-requisites in order to be useful:
@@ -24,7 +23,7 @@ Sidero also needs these co-requisites in order to be useful:
 - [Cluster API Control Plane Provider Talos](https://github.com/talos-systems/cluster-api-control-plane-provider-talos)
 - [Cluster API Bootstrap Provider Talos](https://github.com/talos-systems/cluster-api-bootstrap-provider-talos)
 
-All componenets mentioned above can be installed using Cluster API's `clusterctl` tool.
+All components mentioned above can be installed using Cluster API's `clusterctl` tool.
 
 Because of the design of Cluster API, there is inherently a "chicken and egg" problem with needing an existing Kubernetes cluster in order to provision the management plane.
 Talos Systems and the Cluster API community have created tools to help make this transition easier.


### PR DESCRIPTION
Bump references to Talos, remove explicit `Metadata Server` component as
it got merged into `metal-controller-manager`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>