### PR TITLE
feat: add label selector to serverclass

### DIFF
--- a/app/metal-controller-manager/api/v1alpha1/serverclass_types.go
+++ b/app/metal-controller-manager/api/v1alpha1/serverclass_types.go
@@ -22,6 +22,7 @@ type Qualifiers struct {
 type ServerClassSpec struct {
 	EnvironmentRef *corev1.ObjectReference `json:"environmentRef,omitempty"`
 	Qualifiers     Qualifiers              `json:"qualifiers"`
+	Selector       metav1.LabelSelector    `json:"selector"`
 	ConfigPatches  []ConfigPatches         `json:"configPatches,omitempty"`
 }
 

--- a/app/metal-controller-manager/api/v1alpha1/zz_generated.deepcopy.go
+++ b/app/metal-controller-manager/api/v1alpha1/zz_generated.deepcopy.go
@@ -417,6 +417,7 @@ func (in *ServerClassSpec) DeepCopyInto(out *ServerClassSpec) {
 		**out = **in
 	}
 	in.Qualifiers.DeepCopyInto(&out.Qualifiers)
+	in.Selector.DeepCopyInto(&out.Selector)
 	if in.ConfigPatches != nil {
 		in, out := &in.ConfigPatches, &out.ConfigPatches
 		*out = make([]ConfigPatches, len(*in))

--- a/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_serverclasses.yaml
+++ b/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_serverclasses.yaml
@@ -80,6 +80,36 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+              selector:
+                description: Label selector for servers.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
               qualifiers:
                 properties:
                   cpu:

--- a/app/metal-controller-manager/config/samples/metal_v1alpha1_server.yaml
+++ b/app/metal-controller-manager/config/samples/metal_v1alpha1_server.yaml
@@ -1,7 +1,27 @@
 apiVersion: metal.sidero.dev/v1alpha1
 kind: Server
 metadata:
-  name: server-sample
+  name: 00000000-0000-0000-0000-d05099d333e0
+  labels:
+    common-label: "true"
+    zone: east
+    environment: test
 spec:
-  # Add fields here
-  foo: bar
+  accepted: false
+  configPatches:
+    - op: replace
+      path: /cluster/network/cni
+      value:
+        name: custom
+        urls:
+          - http://192.168.1.199/assets/cilium.yaml
+  cpu:
+    manufacturer: Intel(R) Corporation
+    version: Intel(R) Atom(TM) CPU C3558 @ 2.20GHz
+  system:
+    family: Unknown
+    manufacturer: Unknown
+    productName: Unknown
+    serialNumber: Unknown
+    skuNumber: Unknown
+    version: Unknown

--- a/app/metal-controller-manager/config/samples/metal_v1alpha1_serverclass.yaml
+++ b/app/metal-controller-manager/config/samples/metal_v1alpha1_serverclass.yaml
@@ -3,6 +3,19 @@ kind: ServerClass
 metadata:
   name: serverclass-sample
 spec:
+  selector:
+    matchLabels:
+      common-label: "true"
+    matchExpressions:
+      - key: zone
+        operator: In
+        values:
+          - central
+          - east
+      - key: environment
+        operator: NotIn
+        values:
+          - prod
   qualifiers:
     cpu:
       - manufacturer: "Intel(R) Corporation"
@@ -14,6 +27,3 @@ spec:
         serialNumber: Unknown
         skuNumber: Unknown
         version: Unknown
-    labelSelectors:
-      - key1: "val1"
-      - key2: "val2"

--- a/app/metal-controller-manager/controllers/serverclass_controller.go
+++ b/app/metal-controller-manager/controllers/serverclass_controller.go
@@ -70,7 +70,14 @@ func (r *ServerClassReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		return ctrl.Result{}, fmt.Errorf("unable to get serverclass: %w", err)
 	}
 
-	results := metalv1alpha1.FilterAcceptedServers(sl.Items, sc.Spec.Qualifiers)
+	results, err := metalv1alpha1.FilterServers(sl.Items,
+		metalv1alpha1.AcceptedServerFilter,
+		sc.SelectorFilter(),
+		sc.QualifiersFilter(),
+	)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to filter servers: %w", err)
+	}
 
 	avail := []string{}
 	used := []string{}

--- a/website/content/docs/v0.3/Configuration/servers.md
+++ b/website/content/docs/v0.3/Configuration/servers.md
@@ -15,6 +15,10 @@ apiVersion: metal.sidero.dev/v1alpha1
 kind: Server
 metadata:
   name: 00000000-0000-0000-0000-d05099d333e0
+  labels:
+    common-label: "true"
+    zone: east
+    environment: test
 spec:
   accepted: false
   configPatches:
@@ -28,12 +32,7 @@ spec:
     manufacturer: Intel(R) Corporation
     version: Intel(R) Atom(TM) CPU C3558 @ 2.20GHz
   system:
-    family: Unknown
-    manufacturer: Unknown
-    productName: Unknown
-    serialNumber: Unknown
-    skuNumber: Unknown
-    version: Unknown
+    manufacturer: Dell Inc.
 ```
 
 ## Installation Disk


### PR DESCRIPTION
Adds field `selector` to the root of the ServerClassSpec.

This implements the same schema/logic for selecting Servers as is
used in several builtin Kubernetes APIs.

Tests have been added to show the behavior when both `selector` and
`qualifiers` are used, as well as when neither are used.

https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/label-selector/

Signed-off-by: bzub <bzubrod@gmail.com>

Closes #282 