### PR TITLE
chore: check for dirtiness of the source tree

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,6 +21,20 @@ steps:
       - name: docker
         path: /root/.docker/buildx
 
+  - name: check-dirty
+    image: autonomy/build-container:latest
+    pull: always
+    commands:
+      - make generate manifests
+      - make check-dirty
+    volumes:
+      - name: docker-socket
+        path: /var/run
+      - name: outerdockersock
+        path: /var/outer-run
+      - name: docker
+        path: /root/.docker/buildx
+
   - name: lint-pull-request
     image: autonomy/build-container:latest
     pull: always
@@ -226,6 +240,6 @@ depends_on:
   - default
 ---
 kind: signature
-hmac: 91cb4a5779732a7cd24e222da0862c8993441fe56cde03f330c0dd42b18a5ea7
+hmac: 04c7419d7c3f8495fc1f98d0a44f04adf1cbefe83490598592c5017ae93830d8
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ generate: ## Generate source code.
 manifests: ## Generate manifests (e.g. CRD, RBAC, etc.).
 	@$(MAKE) local-$@ DEST=./ PLATFORM=linux/amd64
 
+.PHONY: check-dirty
+check-dirty: ## Verifies that source tree is not dirty
+	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; exit 1 ; fi
+
 # Artifacts
 
 .PHONY: release


### PR DESCRIPTION
Prevents PRs which have some files not regenerated properly.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>