### PR TITLE
fix: make server class qualifiers and selectors optional

### DIFF
--- a/app/metal-controller-manager/api/v1alpha1/serverclass_types.go
+++ b/app/metal-controller-manager/api/v1alpha1/serverclass_types.go
@@ -20,10 +20,23 @@ type Qualifiers struct {
 
 // ServerClassSpec defines the desired state of ServerClass.
 type ServerClassSpec struct {
+	// Reference to the environment which should be used to provision the servers via this server class.
+	// +optional
 	EnvironmentRef *corev1.ObjectReference `json:"environmentRef,omitempty"`
-	Qualifiers     Qualifiers              `json:"qualifiers"`
-	Selector       metav1.LabelSelector    `json:"selector"`
-	ConfigPatches  []ConfigPatches         `json:"configPatches,omitempty"`
+	// Qualifiers to match on the server spec.
+	//
+	// If qualifiers are empty, they match all servers.
+	// Server should match both qualifiers and selector conditions to be included into the server class.
+	// +optional
+	Qualifiers Qualifiers `json:"qualifiers"`
+	// Label selector to filter the matching servers based on labels.
+	// A label selector is a label query over a set of resources. The result of matchLabels and
+	// matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+	// +optional
+	Selector metav1.LabelSelector `json:"selector"`
+	// Set of config patches to apply to the machine configuration to the servers provisioned via this server class.
+	// +optional
+	ConfigPatches []ConfigPatches `json:"configPatches,omitempty"`
 }
 
 // ServerClassStatus defines the observed state of ServerClass.

--- a/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_serverclasses.yaml
+++ b/app/metal-controller-manager/config/crd/bases/metal.sidero.dev_serverclasses.yaml
@@ -42,6 +42,7 @@ spec:
             description: ServerClassSpec defines the desired state of ServerClass.
             properties:
               configPatches:
+                description: Set of config patches to apply to the machine configuration to the servers provisioned via this server class.
                 items:
                   properties:
                     op:
@@ -56,7 +57,7 @@ spec:
                   type: object
                 type: array
               environmentRef:
-                description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                description: Reference to the environment which should be used to provision the servers via this server class.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -81,6 +82,7 @@ spec:
                     type: string
                 type: object
               qualifiers:
+                description: "Qualifiers to match on the server spec. \n If qualifiers are empty, they match all servers. Server should match both qualifiers and selector conditions to be included into the server class."
                 properties:
                   cpu:
                     items:
@@ -116,7 +118,7 @@ spec:
                     type: array
                 type: object
               selector:
-                description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                description: Label selector to filter the matching servers based on labels. A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -145,9 +147,6 @@ spec:
                     description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
-            required:
-            - qualifiers
-            - selector
             type: object
           status:
             description: ServerClassStatus defines the observed state of ServerClass.


### PR DESCRIPTION
As we actually don't require any of them to be set, mark them as
optional.

This fixes upgrade path from Sidero 0.2 to 0.3.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>