### PR TITLE
feat: update default Talos version to v0.10.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MODULE := $(shell head -1 go.mod | cut -d' ' -f2)
 
 ARTIFACTS := _out
 TEST_PKGS ?= ./...
-TALOS_RELEASE ?= v0.10.2
+TALOS_RELEASE ?= v0.10.3
 
 TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0
 PKGS ?= v0.5.0-8-gb0d9cd2

--- a/app/sidero-controller-manager/config/samples/metal_v1alpha1_environment.yaml
+++ b/app/sidero-controller-manager/config/samples/metal_v1alpha1_environment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.10.2/vmlinuz-amd64"
+    url: "https://github.com/talos-systems/talos/releases/download/v0.10.3/vmlinuz-amd64"
     sha512: ""
     args:
       - console=tty0
@@ -24,5 +24,5 @@ spec:
       - talos.config=http://192.168.1.10:8081/configdata?uuid=
       - talos.platform=metal
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.10.2/initramfs-amd64.xz"
+    url: "https://github.com/talos-systems/talos/releases/download/v0.10.3/initramfs-amd64.xz"
     sha512: ""

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/talos-systems/go-retry v0.3.0
 	github.com/talos-systems/go-smbios v0.0.0-20210422124317-d3a32bea731a
 	github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa
-	github.com/talos-systems/talos/pkg/machinery v0.0.0-20210513202018-8d73bc5999b4 // v0.10.2
+	github.com/talos-systems/talos/pkg/machinery v0.0.0-20210520132439-70ee15b793fb // v0.10.3
 	go.uber.org/zap v1.16.0 // indirect
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 // indirect
 	golang.org/x/mod v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
-github.com/containerd/containerd v1.4.5 h1:H9qDQn8YFhDnHp8Qp9A1GGHlAhN8WicvgvfgpqRGUr8=
-github.com/containerd/containerd v1.4.5/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.4.6 h1:mdXu4r70lQky9rbOBtodOuYDDK/VKEGVK3FLdhTGkFc=
+github.com/containerd/containerd v1.4.6/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/go-cni v1.0.1 h1:VXr2EkOPD0v1gu7CKfof6XzEIDzsE/dI9yj/W7PSWLs=
 github.com/containerd/go-cni v1.0.1/go.mod h1:+vUpYxKvAF72G9i1WoDOiPGRtQpqsNW/ZHtSlv++smU=
 github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjMCbgybcKI=
@@ -521,8 +521,8 @@ github.com/talos-systems/os-runtime v0.0.0-20210216141502-28dd9aaf98d6/go.mod h1
 github.com/talos-systems/talos/pkg/machinery v0.0.0-20210216142802-8d7a36cc0cc2/go.mod h1:hhWsbfLrP53M03VRmJ5j92yimTHx0NBwngaXnvKkPE0=
 github.com/talos-systems/talos/pkg/machinery v0.0.0-20210216142802-8d7a36cc0cc2/go.mod h1:hhWsbfLrP53M03VRmJ5j92yimTHx0NBwngaXnvKkPE0=
 github.com/talos-systems/talos/pkg/machinery v0.0.0-20210218160848-32d25885288f/go.mod h1:7xqrV27kGtf2On8mrFjhv6dlNBRvtYsr+1npSZXJDlc=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20210513202018-8d73bc5999b4 h1:azrJdauho93eMpb3ufIO1gf087c17/8DOBK0nfuC/CI=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20210513202018-8d73bc5999b4/go.mod h1:v/I3uBRKB3P04fnBeM1e9i/4XkzgE2HYE3tLc8f1VP0=
+github.com/talos-systems/talos/pkg/machinery v0.0.0-20210520132439-70ee15b793fb h1:4kbvoWOQrwh5+YPa1tFtukG3VOnB2MzHAxF3K0A+U3U=
+github.com/talos-systems/talos/pkg/machinery v0.0.0-20210520132439-70ee15b793fb/go.mod h1:aFEgwo1bYcfADnnUCndIb8hT00WYHYCy77pq9tYocF4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/sfyra/go.mod
+++ b/sfyra/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa
 	github.com/talos-systems/sidero v0.0.0-00010101000000-000000000000
 	github.com/talos-systems/talos v0.10.0-alpha.2.0.20210518203841-d3d9112f288d // 0.11-alpha to get DefaultBootOrder
-	github.com/talos-systems/talos/pkg/machinery v0.0.0-20210513202018-8d73bc5999b4 // v0.10.2
+	github.com/talos-systems/talos/pkg/machinery v0.0.0-20210520132439-70ee15b793fb // v0.10.3
 	google.golang.org/grpc v1.38.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.21.0

--- a/sfyra/go.sum
+++ b/sfyra/go.sum
@@ -222,7 +222,7 @@ github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMX
 github.com/containerd/containerd v1.4.0-beta.2.0.20200729163537-40b22ef07410/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.3/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
-github.com/containerd/containerd v1.4.5/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.4.6/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.5.0-beta.1/go.mod h1:5HfvG1V2FsKesEGQ17k5/T7V960Tmcumvqn8Mc+pCYQ=
 github.com/containerd/containerd v1.5.0-beta.3/go.mod h1:/wr9AVtEM7x9c+n0+stptlo/uBBoBORwEx6ardVcmKU=
 github.com/containerd/containerd v1.5.0-beta.4/go.mod h1:GmdgZd2zA2GYIBZ0w09ZvgqEq8EfBp/m3lcVZIvPHhI=
@@ -1195,8 +1195,8 @@ github.com/talos-systems/talos v0.10.0-alpha.2.0.20210518203841-d3d9112f288d/go.
 github.com/talos-systems/talos/pkg/machinery v0.0.0-20210216142802-8d7a36cc0cc2/go.mod h1:hhWsbfLrP53M03VRmJ5j92yimTHx0NBwngaXnvKkPE0=
 github.com/talos-systems/talos/pkg/machinery v0.0.0-20210218160848-32d25885288f/go.mod h1:7xqrV27kGtf2On8mrFjhv6dlNBRvtYsr+1npSZXJDlc=
 github.com/talos-systems/talos/pkg/machinery v0.0.0-20210302191918-8ffb55943c71/go.mod h1:iXEEFjuw0F65yZw10nKBd8XI4SBQNfJ0J02Mt26pfkA=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20210513202018-8d73bc5999b4 h1:azrJdauho93eMpb3ufIO1gf087c17/8DOBK0nfuC/CI=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20210513202018-8d73bc5999b4/go.mod h1:v/I3uBRKB3P04fnBeM1e9i/4XkzgE2HYE3tLc8f1VP0=
+github.com/talos-systems/talos/pkg/machinery v0.0.0-20210520132439-70ee15b793fb h1:4kbvoWOQrwh5+YPa1tFtukG3VOnB2MzHAxF3K0A+U3U=
+github.com/talos-systems/talos/pkg/machinery v0.0.0-20210520132439-70ee15b793fb/go.mod h1:aFEgwo1bYcfADnnUCndIb8hT00WYHYCy77pq9tYocF4=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/website/content/docs/v0.3/Configuration/environments.md
+++ b/website/content/docs/v0.3/Configuration/environments.md
@@ -26,7 +26,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.10.2/vmlinuz-amd64"
+    url: "https://github.com/talos-systems/talos/releases/download/v0.10.3/vmlinuz-amd64"
     sha512: ""
     args:
       - console=tty0
@@ -46,7 +46,7 @@ spec:
       - talos.config=http://$PUBLIC_IP:8081/configdata?uuid=
       - talos.platform=metal
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.10.2/initramfs-amd64.xz"
+    url: "https://github.com/talos-systems/talos/releases/download/v0.10.3/initramfs-amd64.xz"
     sha512: ""
 ```
 


### PR DESCRIPTION
This updates to the latest stable Talos release before cutting Sidero
0.3 final release.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
(cherry picked from commit bf2be1b1569333034cadd2dacc023538221b2930)