### PR TITLE
fix: update Sfyra to install CAPI v0.3

### DIFF
--- a/sfyra/cmd/sfyra/cmd/bootstrap_capi.go
+++ b/sfyra/cmd/sfyra/cmd/bootstrap_capi.go
@@ -47,6 +47,7 @@ var bootstrapCAPICmd = &cobra.Command{
 
 			clusterAPI, err := capi.NewManager(ctx, bootstrapCluster, capi.Options{
 				ClusterctlConfigPath:    options.ClusterctlConfigPath,
+				CoreProvider:            options.CoreProvider,
 				BootstrapProviders:      options.BootstrapProviders,
 				InfrastructureProviders: options.InfrastructureProviders,
 				ControlPlaneProviders:   options.ControlPlaneProviders,

--- a/sfyra/cmd/sfyra/cmd/options.go
+++ b/sfyra/cmd/sfyra/cmd/options.go
@@ -21,6 +21,7 @@ type Options struct {
 	TalosInitrdURL string
 
 	ClusterctlConfigPath    string
+	CoreProvider            string
 	BootstrapProviders      []string
 	InfrastructureProviders []string
 	ControlPlaneProviders   []string
@@ -63,6 +64,7 @@ func DefaultOptions() Options {
 		TalosKernelURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/vmlinuz-amd64", TalosRelease),
 		TalosInitrdURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/initramfs-amd64.xz", TalosRelease),
 
+		CoreProvider:            "cluster-api:v0.3.19",
 		BootstrapProviders:      []string{"talos"},
 		InfrastructureProviders: []string{"sidero"},
 		ControlPlaneProviders:   []string{"talos"},

--- a/sfyra/cmd/sfyra/cmd/test_integration.go
+++ b/sfyra/cmd/sfyra/cmd/test_integration.go
@@ -84,6 +84,7 @@ var testIntegrationCmd = &cobra.Command{
 
 			clusterAPI, err := capi.NewManager(ctx, bootstrapCluster, capi.Options{
 				ClusterctlConfigPath:    options.ClusterctlConfigPath,
+				CoreProvider:            options.CoreProvider,
 				BootstrapProviders:      options.BootstrapProviders,
 				InfrastructureProviders: options.InfrastructureProviders,
 				ControlPlaneProviders:   options.ControlPlaneProviders,

--- a/sfyra/pkg/capi/capi.go
+++ b/sfyra/pkg/capi/capi.go
@@ -34,6 +34,7 @@ type Manager struct {
 // Options for the CAPI installer.
 type Options struct {
 	ClusterctlConfigPath    string
+	CoreProvider            string
 	BootstrapProviders      []string
 	InfrastructureProviders []string
 	ControlPlaneProviders   []string
@@ -128,7 +129,7 @@ func (clusterAPI *Manager) Install(ctx context.Context) error {
 
 	options := client.InitOptions{
 		Kubeconfig:              kubeconfig,
-		CoreProvider:            "",
+		CoreProvider:            clusterAPI.options.CoreProvider,
 		BootstrapProviders:      clusterAPI.options.BootstrapProviders,
 		ControlPlaneProviders:   clusterAPI.options.ControlPlaneProviders,
 		InfrastructureProviders: clusterAPI.options.InfrastructureProviders,


### PR DESCRIPTION
This fixes a problem that our providers are not v1alpha4 ready yet.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>