### PR TITLE
docs: fix duplicate titles in the guides

### DIFF
--- a/website/content/docs/v0.2/Getting Started/create-workload.md
+++ b/website/content/docs/v0.2/Getting Started/create-workload.md
@@ -1,9 +1,8 @@
 ---
 description: "Create a Workload Cluster"
 weight: 8
+title: "Create a Workload Cluster"
 ---
-
-# Create a Workload Cluster
 
 Once created and accepted, you should see the servers that make up your ServerClasses appear as "available":
 

--- a/website/content/docs/v0.2/Getting Started/expose-services.md
+++ b/website/content/docs/v0.2/Getting Started/expose-services.md
@@ -1,9 +1,8 @@
 ---
 description: "A guide for bootstrapping Sidero management plane"
 weight: 6
+title: "Expose Sidero Services"
 ---
-
-# Expose Sidero Services
 
 > If you built your cluster as specified in the [Prerequisite: Kubernetes] section in this tutorial, your services are already exposed and you can skip this section.
 

--- a/website/content/docs/v0.2/Getting Started/import-machines.md
+++ b/website/content/docs/v0.2/Getting Started/import-machines.md
@@ -1,9 +1,8 @@
 ---
 description: "A guide for bootstrapping Sidero management plane"
 weight: 7
+title: "Import Workload Machines"
 ---
-
-# Import Workload Machines
 
 At this point, any servers on the same network as Sidero should network boot from Sidero.
 To register a server with Sidero, simply turn it on and Sidero will do the rest.

--- a/website/content/docs/v0.2/Getting Started/index.md
+++ b/website/content/docs/v0.2/Getting Started/index.md
@@ -1,9 +1,8 @@
 ---
 description: "Overview"
 weight: 1
+title: "Overview"
 ---
-
-# Overview
 
 This tutorial will walk you through a complete Sidero setup and the formation,
 scaling, and destruction of a workload cluster.

--- a/website/content/docs/v0.2/Getting Started/install-clusterapi.md
+++ b/website/content/docs/v0.2/Getting Started/install-clusterapi.md
@@ -1,9 +1,8 @@
 ---
 description: "Install Sidero"
 weight: 5
+title: "Install Sidero"
 ---
-
-# Install Sidero
 
 Sidero is included as a default infrastructure provider in `clusterctl`, so the
 installation of both Sidero and the Cluster API (CAPI) components is as simple

--- a/website/content/docs/v0.2/Getting Started/pivot.md
+++ b/website/content/docs/v0.2/Getting Started/pivot.md
@@ -1,9 +1,8 @@
 ---
 description: "A guide for bootstrapping Sidero management plane"
 weight: 11
+title: "Optional: Pivot management cluster"
 ---
-
-# Optional: Pivot management cluster
 
 Having the Sidero cluster running inside a Docker container is not the most
 robust place for it, but it did make for an expedient start.

--- a/website/content/docs/v0.2/Getting Started/prereq-cli-tools.md
+++ b/website/content/docs/v0.2/Getting Started/prereq-cli-tools.md
@@ -1,9 +1,8 @@
 ---
 description: "Prerequisite: CLI tools"
 weight: 99
+title: "Prerequisite: CLI tools"
 ---
-
-# Prerequisite: CLI tools
 
 You will need three CLI tools installed on your workstation in order to interact
 with Sidero:

--- a/website/content/docs/v0.2/Getting Started/prereq-dhcp.md
+++ b/website/content/docs/v0.2/Getting Started/prereq-dhcp.md
@@ -1,9 +1,8 @@
 ---
 description: "Prerequisite: DHCP Service"
 weight: 99
+title: "Prerequisite: DHCP service"
 ---
-
-# Prerequisite: DHCP service
 
 In order to network boot Talos, we need to set up our DHCP server to supply the
 network boot parameters to our servers.

--- a/website/content/docs/v0.2/Getting Started/prereq-kubernetes.md
+++ b/website/content/docs/v0.2/Getting Started/prereq-kubernetes.md
@@ -1,9 +1,8 @@
 ---
 description: "Prerequisite: Kubernetes"
 weight: 99
+title: "Prerequisite: Kubernetes"
 ---
-
-# Prerequisite: Kubernetes
 
 In order to run Sidero, you first need a Kubernetes "cluster".
 There is nothing special about this cluster.

--- a/website/content/docs/v0.2/Getting Started/scale-workload.md
+++ b/website/content/docs/v0.2/Getting Started/scale-workload.md
@@ -1,9 +1,8 @@
 ---
 description: "A guide for bootstrapping Sidero management plane"
 weight: 9
+title: "Scale the Workload Cluster"
 ---
-
-# Scale the Workload Cluster
 
 If you have more machines available, you can scale both the controlplane
 (`TalosControlPlane`) and the workers (`MachineDeployment`) for any cluster

--- a/website/content/docs/v0.2/Getting Started/troubleshooting.md
+++ b/website/content/docs/v0.2/Getting Started/troubleshooting.md
@@ -1,9 +1,8 @@
 ---
 description: "Troubleshooting"
 weight: 99
+title: "Troubleshooting"
 ---
-
-# Troubleshooting
 
 The first thing to do in troubleshooting problems with the Sidero installation
 and operation is to figure out _where_ in the process that failure is occurring.

--- a/website/content/docs/v0.3/Getting Started/create-workload.md
+++ b/website/content/docs/v0.3/Getting Started/create-workload.md
@@ -1,9 +1,8 @@
 ---
 description: "Create a Workload Cluster"
 weight: 8
+title: "Create a Workload Cluster"
 ---
-
-# Create a Workload Cluster
 
 Once created and accepted, you should see the servers that make up your ServerClasses appear as "available":
 

--- a/website/content/docs/v0.3/Getting Started/expose-services.md
+++ b/website/content/docs/v0.3/Getting Started/expose-services.md
@@ -1,9 +1,8 @@
 ---
 description: "A guide for bootstrapping Sidero management plane"
 weight: 6
+title: "Expose Sidero Services"
 ---
-
-# Expose Sidero Services
 
 > If you built your cluster as specified in the [Prerequisite: Kubernetes] section in this tutorial, your services are already exposed and you can skip this section.
 

--- a/website/content/docs/v0.3/Getting Started/import-machines.md
+++ b/website/content/docs/v0.3/Getting Started/import-machines.md
@@ -1,9 +1,8 @@
 ---
 description: "A guide for bootstrapping Sidero management plane"
 weight: 7
+title: "Import Workload Machines"
 ---
-
-# Import Workload Machines
 
 At this point, any servers on the same network as Sidero should network boot from Sidero.
 To register a server with Sidero, simply turn it on and Sidero will do the rest.

--- a/website/content/docs/v0.3/Getting Started/index.md
+++ b/website/content/docs/v0.3/Getting Started/index.md
@@ -1,9 +1,8 @@
 ---
 description: "Overview"
 weight: 1
+title: "Overview"
 ---
-
-# Overview
 
 This tutorial will walk you through a complete Sidero setup and the formation,
 scaling, and destruction of a workload cluster.

--- a/website/content/docs/v0.3/Getting Started/install-clusterapi.md
+++ b/website/content/docs/v0.3/Getting Started/install-clusterapi.md
@@ -1,9 +1,8 @@
 ---
 description: "Install Sidero"
 weight: 5
+title: "Install Sidero"
 ---
-
-# Install Sidero
 
 Sidero is included as a default infrastructure provider in `clusterctl`, so the
 installation of both Sidero and the Cluster API (CAPI) components is as simple

--- a/website/content/docs/v0.3/Getting Started/pivot.md
+++ b/website/content/docs/v0.3/Getting Started/pivot.md
@@ -1,9 +1,8 @@
 ---
 description: "A guide for bootstrapping Sidero management plane"
 weight: 11
+title: "Optional: Pivot management cluster"
 ---
-
-# Optional: Pivot management cluster
 
 Having the Sidero cluster running inside a Docker container is not the most
 robust place for it, but it did make for an expedient start.

--- a/website/content/docs/v0.3/Getting Started/prereq-cli-tools.md
+++ b/website/content/docs/v0.3/Getting Started/prereq-cli-tools.md
@@ -1,9 +1,8 @@
 ---
 description: "Prerequisite: CLI tools"
 weight: 99
+title: "Prerequisite: CLI tools"
 ---
-
-# Prerequisite: CLI tools
 
 You will need three CLI tools installed on your workstation in order to interact
 with Sidero:

--- a/website/content/docs/v0.3/Getting Started/prereq-dhcp.md
+++ b/website/content/docs/v0.3/Getting Started/prereq-dhcp.md
@@ -1,9 +1,8 @@
 ---
 description: "Prerequisite: DHCP Service"
 weight: 99
+title: "Prerequisite: DHCP service"
 ---
-
-# Prerequisite: DHCP service
 
 In order to network boot Talos, we need to set up our DHCP server to supply the
 network boot parameters to our servers.

--- a/website/content/docs/v0.3/Getting Started/prereq-kubernetes.md
+++ b/website/content/docs/v0.3/Getting Started/prereq-kubernetes.md
@@ -1,9 +1,8 @@
 ---
 description: "Prerequisite: Kubernetes"
 weight: 99
+title: "Prerequisite: Kubernetes"
 ---
-
-# Prerequisite: Kubernetes
 
 In order to run Sidero, you first need a Kubernetes "cluster".
 There is nothing special about this cluster.

--- a/website/content/docs/v0.3/Getting Started/scale-workload.md
+++ b/website/content/docs/v0.3/Getting Started/scale-workload.md
@@ -1,9 +1,8 @@
 ---
 description: "A guide for bootstrapping Sidero management plane"
 weight: 9
+title: "Scale the Workload Cluster"
 ---
-
-# Scale the Workload Cluster
 
 If you have more machines available, you can scale both the controlplane
 (`TalosControlPlane`) and the workers (`MachineDeployment`) for any cluster

--- a/website/content/docs/v0.3/Getting Started/troubleshooting.md
+++ b/website/content/docs/v0.3/Getting Started/troubleshooting.md
@@ -1,9 +1,8 @@
 ---
 description: "Troubleshooting"
 weight: 99
+title: "Troubleshooting"
 ---
-
-# Troubleshooting
 
 The first thing to do in troubleshooting problems with the Sidero installation
 and operation is to figure out _where_ in the process that failure is occurring.


### PR DESCRIPTION
We should put H1 title to the metadata section of the document.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>