### PR TITLE
fix: make sure powercycle condition gets properly updated

### DIFF
--- a/app/sidero-controller-manager/controllers/server_controller.go
+++ b/app/sidero-controller-manager/controllers/server_controller.go
@@ -270,9 +270,8 @@ func (r *ServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 				r.Recorder.Event(serverRef, corev1.EventTypeNormal, "Server Management", "Server powered on and set to PXE boot once.")
 			}
 
-			// remove the condition in case it was already set to make sure LastTransitionTime will be updated
-			conditions.Delete(&s, metalv1alpha1.ConditionPowerCycle)
-			conditions.MarkFalse(&s, metalv1alpha1.ConditionPowerCycle, "InProgress", clusterv1.ConditionSeverityInfo, "Server power cycled for wiping.")
+			// make sure message is updated in case condition was already set to make sure LastTransitionTime will be updated
+			conditions.MarkFalse(&s, metalv1alpha1.ConditionPowerCycle, "InProgress", clusterv1.ConditionSeverityInfo, fmt.Sprintf("Server power cycled for wiping at %s.", time.Now().Format(time.RFC3339)))
 		}
 
 		// requeue to check for wipe timeout


### PR DESCRIPTION
We rely on the timestamp of the `PowerCycle` condition to be updated
properly when Sidero reboots the node (assuming previous attempt to PXE
boot failed). Looks like nothing we did before actually ensures that the
condition gets properly updated, so a little hack modifying condition
message to make sure actual condition gets patched properly with last
transition time.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>