### PR TITLE
chore: bump Talos to 0.11.0-beta.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MODULE := $(shell head -1 go.mod | cut -d' ' -f2)
 
 ARTIFACTS := _out
 TEST_PKGS ?= ./...
-TALOS_RELEASE ?= v0.11.0-beta.2
+TALOS_RELEASE ?= v0.11.0-beta.3
 
 TOOLS ?= ghcr.io/talos-systems/tools:v0.6.0
 PKGS ?= v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/talos-systems/go-retry v0.3.1
 	github.com/talos-systems/go-smbios v0.0.0-20210422124317-d3a32bea731a
 	github.com/talos-systems/net v0.3.0
-	github.com/talos-systems/talos/pkg/machinery v0.0.0-20210701194847-1179d6bafc9d // v0.11.0-beta.2
+	github.com/talos-systems/talos/pkg/machinery v0.11.0-beta.3
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 // indirect
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -536,8 +536,8 @@ github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa/go.mod h1:VreS
 github.com/talos-systems/net v0.3.0 h1:TG6PoiNdg9NmSeSjyecSgguUXzoJ8wp5a8RYlIdkq3Y=
 github.com/talos-systems/net v0.3.0/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=
 github.com/talos-systems/talos/pkg/machinery v0.0.0-20210520203624-828772cec9a3/go.mod h1:aFEgwo1bYcfADnnUCndIb8hT00WYHYCy77pq9tYocF4=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20210701194847-1179d6bafc9d h1:nQ+w9nwXC8ViLv80Kys8xoqbC2DmFUuP6EAuDxhVzXI=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20210701194847-1179d6bafc9d/go.mod h1:TH99lX6IMJys9kgBJ6MNIOV0UsxmTVS0fUr7rP5KTac=
+github.com/talos-systems/talos/pkg/machinery v0.11.0-beta.3 h1:FcuM39G7NxrO7iPsIOfS/vgDWbCRhrzkdS+aGLU9aIk=
+github.com/talos-systems/talos/pkg/machinery v0.11.0-beta.3/go.mod h1:TH99lX6IMJys9kgBJ6MNIOV0UsxmTVS0fUr7rP5KTac=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/sfyra/go.mod
+++ b/sfyra/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace (
 	github.com/talos-systems/sidero => ../
 
-	github.com/talos-systems/talos/pkg/machinery => github.com/talos-systems/talos/pkg/machinery v0.0.0-20210701194847-1179d6bafc9d // v0.11.0-beta.2
+	github.com/talos-systems/talos/pkg/machinery => github.com/talos-systems/talos/pkg/machinery v0.11.0-beta.3
 
 	// See https://github.com/talos-systems/go-loadbalancer/pull/4
 	// `go get github.com/smira/tcpproxy@combined-fixes`, then copy pseudo-version there
@@ -30,8 +30,8 @@ require (
 	github.com/talos-systems/go-retry v0.3.1
 	github.com/talos-systems/net v0.3.0
 	github.com/talos-systems/sidero v0.0.0-00010101000000-000000000000
-	github.com/talos-systems/talos v0.11.0-beta.2
-	github.com/talos-systems/talos/pkg/machinery v0.0.0-20210701194847-1179d6bafc9d // v0.11.0-beta.2
+	github.com/talos-systems/talos v0.11.0-beta.3
+	github.com/talos-systems/talos/pkg/machinery v0.11.0-beta.3
 	google.golang.org/grpc v1.39.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.21.2

--- a/sfyra/go.sum
+++ b/sfyra/go.sum
@@ -1119,10 +1119,10 @@ github.com/talos-systems/go-smbios v0.1.0/go.mod h1:HxhrzAoTZ7ed5Z5VvtCvnCIrOxyX
 github.com/talos-systems/grpc-proxy v0.2.0/go.mod h1:sm97Vc/z2cok3pu6ruNeszQej4KDxFrDgfWs4C1mtC4=
 github.com/talos-systems/net v0.3.0 h1:TG6PoiNdg9NmSeSjyecSgguUXzoJ8wp5a8RYlIdkq3Y=
 github.com/talos-systems/net v0.3.0/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=
-github.com/talos-systems/talos v0.11.0-beta.2 h1:HqEyk3U2HAFxyPijEVQ8DHti88HqgnqrMqObebDW+58=
-github.com/talos-systems/talos v0.11.0-beta.2/go.mod h1:Ubg09rmds2/mPcfSh3uedJ2r3AeJKuZ+Aiw6X8Cf6G4=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20210701194847-1179d6bafc9d h1:nQ+w9nwXC8ViLv80Kys8xoqbC2DmFUuP6EAuDxhVzXI=
-github.com/talos-systems/talos/pkg/machinery v0.0.0-20210701194847-1179d6bafc9d/go.mod h1:TH99lX6IMJys9kgBJ6MNIOV0UsxmTVS0fUr7rP5KTac=
+github.com/talos-systems/talos v0.11.0-beta.3 h1:wbxPgsCiBqh6stJP0dCibohAZuQ0+eiBVoh/ZuMbuB0=
+github.com/talos-systems/talos v0.11.0-beta.3/go.mod h1:Ubg09rmds2/mPcfSh3uedJ2r3AeJKuZ+Aiw6X8Cf6G4=
+github.com/talos-systems/talos/pkg/machinery v0.11.0-beta.3 h1:FcuM39G7NxrO7iPsIOfS/vgDWbCRhrzkdS+aGLU9aIk=
+github.com/talos-systems/talos/pkg/machinery v0.11.0-beta.3/go.mod h1:TH99lX6IMJys9kgBJ6MNIOV0UsxmTVS0fUr7rP5KTac=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
More of a testcase for pkg/machinery tags.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>