### PR TITLE
docs: redirect latest to v0.3

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -2,5 +2,5 @@
 #
 # The Netlify documentation says that the following redirect rules are
 # equivalent, but that is not what is observed in practice.
-/docs/latest /docs/v0.2
-/docs/latest/ /docs/v0.2
+/docs/latest /docs/v0.3
+/docs/latest/ /docs/v0.3


### PR DESCRIPTION
This PR updates the redirect rules for making sure latest actually, you
know, points to the latest.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>