### PR TITLE
docs: bump clusterctl from v0.3.14 to v0.3.21 in /docs/website

### DIFF
--- a/website/content/docs/v0.3/Getting Started/prereq-cli-tools.md
+++ b/website/content/docs/v0.3/Getting Started/prereq-cli-tools.md
@@ -39,7 +39,7 @@ The main article for installing `clusterctl` can be found
 
 ```bash
 sudo curl -Lo /usr/local/bin/clusterctl \
-  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.14/clusterctl-linux-amd64" \
+  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.21/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64" \
 sudo chmod +x /usr/local/bin/clusterctl
 ```
 


### PR DESCRIPTION
Fix incompatible API version:

```
Error: installing provider "bootstrap-talos" can lead to a non functioning management cluster: the target version for the provider supports the v1alpha3 API Version of Cluster API (contract), while the management group is using v1alpha4
```

Related Cluster API documentation: https://cluster-api.sigs.k8s.io/clusterctl/provider-contract.html#note-on-user-experience

Signed-off-by: Khue Doan khuedoan98@gmail.com