### PR TITLE
fix: update sidero IPMI user to work properly on idrac

### DIFF
--- a/app/sidero-controller-manager/cmd/agent/main.go
+++ b/app/sidero-controller-manager/cmd/agent/main.go
@@ -541,10 +541,10 @@ func attemptBMCUserSetup(ctx context.Context, client api.AgentClient, s *smbios.
 	}
 
 	// Make sidero an admin
-	// Options: 0xD1 == Callin false, Link false, IPMI Msg true, Channel 1
+	// Options: 0x91 == Callin true, Link false, IPMI Msg true, Channel 1
 	// Limits: 0x03 == Administrator
 	// Session: 0x00 No session limit
-	_, err = ipmiClient.SetUserAccess(0xD1, sideroUserID, 0x04, 0x00)
+	_, err = ipmiClient.SetUserAccess(0x91, sideroUserID, 0x04, 0x00)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR makes sure that the sidero user gets the `callin=true` access.
Setting this for these sidero users seems to function just fine on tests of both
iDrac and ASROCK BMCs.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
