### PR TITLE
fix: broken url, ServerClass CR spec

### DIFF
--- a/website/content/docs/v0.3/Guides/iso.md
+++ b/website/content/docs/v0.3/Guides/iso.md
@@ -12,7 +12,7 @@ For folks who are willing to take care of their management plane in other ways, 
 
 The rough outline of this process is very short and sweet, as it relies on other documentation:
 
-- For each management plane node, boot the ISO and install Talos using the "apply-config" process mentioned in our Talos [Getting Started](https://www.talos.dev/docs/v0.10/introduction/getting-started/) docs.
+- For each management plane node, boot the ISO and install Talos using the "apply-config" process mentioned in our Talos [Getting Started](https://www.talos.dev/docs/v0.11/introduction/getting-started/) docs.
   These docs go into heavy detail on using the ISO, so they will not be recreated here.
 
 - With a Kubernetes cluster now in hand (and with access to it via `talosctl` and `kubectl`), you can simply pickup the Getting Started tutorial at the "Install Sidero" section [here](../../getting-started/install-clusterapi).
@@ -20,4 +20,4 @@ The rough outline of this process is very short and sweet, as it relies on other
 
 > Note: It may also be of interest to view the prereq guides on [CLI](../../getting-started/prereq-cli-tools) and [DHCP](../../getting-started/prereq-dhcp) setup, as they will still apply to this method.
 
-- For long-term maintenance of a management plane created in this way, refer to the Talos documentation for upgrading [Kubernetes](https://www.talos.dev/docs/v0.10/guides/upgrading-kubernetes/) and [Talos](https://www.talos.dev/docs/v0.10/guides/upgrading-talos/) itself.
+- For long-term maintenance of a management plane created in this way, refer to the Talos documentation for upgrading [Kubernetes](https://www.talos.dev/docs/v0.11/guides/upgrading-kubernetes/) and [Talos](https://www.talos.dev/docs/v0.11/guides/upgrading-talos/) itself.

--- a/website/content/docs/v0.3/Guides/patching.md
+++ b/website/content/docs/v0.3/Guides/patching.md
@@ -5,7 +5,7 @@ title: "Patching"
 ---
 
 Server resources can be updated by using the `configPatches` section of the custom resource.
-Any field of the [Talos machine config](https://www.talos.dev/docs/v0.8/reference/configuration/)
+Any field of the [Talos machine config](https://www.talos.dev/docs/v0.11/reference/configuration/)
 can be overridden on a per-machine basis using this method.
 The format of these patches is based on [JSON 6902](http://jsonpatch.com/) that you may be used to in tools like kustomize.
 
@@ -54,4 +54,4 @@ If it doesn't exist, create it with the `op: add` above the `op: replace` patch.
 ## Combining Patches from Multiple Sources
 
 Config patches might be combined from multiple sources (`Server`, `ServerClass`), which is explained in details
-in [Metadata](../../configuration/metadata/) section.
+in [Metadata](../../resource-configuration/metadata/) section.

--- a/website/content/docs/v0.3/Guides/rpi4-as-servers.md
+++ b/website/content/docs/v0.3/Guides/rpi4-as-servers.md
@@ -30,7 +30,7 @@ We will use the EEPROM to boot into UEFI, which we will then use to PXE and iPXE
 
 ### Update EEPROM
 
-_NOTE:_ If you've updated the EEPROM with the image that was referenced on [the talos docs](https://www.talos.dev/docs/v0.10/single-board-computers/rpi_4/#updating-the-eeprom),
+_NOTE:_ If you've updated the EEPROM with the image that was referenced on [the talos docs](https://www.talos.dev/docs/v0.11/single-board-computers/rpi_4/#updating-the-eeprom),
 you can either flash it with the one mentioned below, or visit [the EEPROM config docs](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711_bootloader_config.md)
 and change the boot order of EEPROM to `0xf21`.
 Which means try booting from SD first, then try network.

--- a/website/content/docs/v0.3/Guides/sidero-on-rpi4.md
+++ b/website/content/docs/v0.3/Guides/sidero-on-rpi4.md
@@ -10,7 +10,7 @@ In this guide, we are going to install Talos on Raspberry Pi4, deploy Sidero and
 
 ## Prerequisites
 
-Please see Talos documentation for additional information on [installing Talos on Raspberry Pi4](https://www.talos.dev/docs/v0.10/single-board-computers/rpi_4/).
+Please see Talos documentation for additional information on [installing Talos on Raspberry Pi4](https://www.talos.dev/docs/v0.11/single-board-computers/rpi_4/).
 
 Download the `clusterctl` CLI  from [CAPI releases](https://github.com/kubernetes-sigs/cluster-api/releases).
 The minimum required version is 0.3.17.
@@ -154,5 +154,5 @@ Configure your DHCP server to PXE boot your bare metal servers from `$SIDERO_END
 
 ## Backup and Recovery
 
-SD cards are not very reliable, so make sure you are taking regular [etcd backups](https://www.talos.dev/docs/v0.10/guides/disaster-recovery/),
-so that you can [recover](https://www.talos.dev/docs/v0.10/guides/disaster-recovery/) your Sidero installation in case of data loss.
+SD cards are not very reliable, so make sure you are taking regular [etcd backups](https://www.talos.dev/docs/v0.11/guides/disaster-recovery/),
+so that you can [recover](https://www.talos.dev/docs/v0.11/guides/disaster-recovery/) your Sidero installation in case of data loss.

--- a/website/content/docs/v0.3/Guides/upgrades.md
+++ b/website/content/docs/v0.3/Guides/upgrades.md
@@ -6,9 +6,9 @@ weight: 5
 
 Upgrading a running workload cluster or management plane is the same process as describe in the Talos documentation.
 
-To upgrade the Talos OS, see [here](https://www.talos.dev/docs/v0.10/guides/upgrading-talos).
+To upgrade the Talos OS, see [here](https://www.talos.dev/docs/v0.11/guides/upgrading-talos).
 
-In order to upgrade Kubernetes itself, see [here](https://www.talos.dev/docs/v0.10/guides/upgrading-kubernetes/).
+In order to upgrade Kubernetes itself, see [here](https://www.talos.dev/docs/v0.11/guides/upgrading-kubernetes/).
 
 ## Upgrading Talos 0.8 -> 0.9
 

--- a/website/content/docs/v0.3/Resource Configuration/environments.md
+++ b/website/content/docs/v0.3/Resource Configuration/environments.md
@@ -8,7 +8,7 @@ Environments are a custom resource provided by the Metal Controller Manager.
 An environment is a codified description of what should be returned by the PXE server when a physical server attempts to PXE boot.
 
 Especially important in the environment types are the kernel args.
-From here, one can tweak the IP to the metadata server as well as various other kernel options that [Talos](https://www.talos.dev/docs/v0.8/introduction/getting-started/#kernel-parameters) and/or the Linux kernel supports.
+From here, one can tweak the IP to the metadata server as well as various other kernel options that [Talos](hhttps://www.talos.dev/docs/v0.11/reference/kernel/#commandline-parameters) and/or the Linux kernel supports.
 
 Environments can be supplied to a given server either at the Server or the ServerClass level.
 The hierarchy from most to least respected is:

--- a/website/content/docs/v0.3/Resource Configuration/metadata.md
+++ b/website/content/docs/v0.3/Resource Configuration/metadata.md
@@ -6,7 +6,7 @@ title: Metadata
 
 The Metadata server manages the Machine metadata.
 In terms of Talos (the OS on which the Kubernetes cluster is formed), this is the
-"[machine config](https://www.talos.dev/docs/v0.10/reference/configuration/)",
+"[machine config](https://www.talos.dev/docs/v0.11/reference/configuration/)",
 which is used during the automated installation.
 
 ## Talos Machine Configuration

--- a/website/content/docs/v0.3/Resource Configuration/serverclasses.md
+++ b/website/content/docs/v0.3/Resource Configuration/serverclasses.md
@@ -48,8 +48,8 @@ spec:
         version: "Intel(R) Atom(TM) CPU C3558 @ 2.20GHz"
       - manufacturer: Advanced Micro Devices, Inc.
         version: AMD Ryzen 7 2700X Eight-Core Processor
-    system:
-      manufacturer: Dell Inc.
+    systemInformation:
+      - manufacturer: Dell Inc.
 ```
 
 Servers would only be added to the above class if they:


### PR DESCRIPTION
update: Talos v0.11 docs

Fix ServerClass CR spec and a broken link
Update to talos v0.11 docs

Signed-off-by: Noel Georgi <git@frezbo.dev>