### PR TITLE
fix: shutdown sidero-controller-manager when any component fails

### DIFF
--- a/app/sidero-controller-manager/config/manager/manager.yaml
+++ b/app/sidero-controller-manager/config/manager/manager.yaml
@@ -65,7 +65,7 @@ spec:
               containerPort: 69
               protocol: UDP
             - name: http
-              containerPort: 8081
+              containerPort: ${SIDERO_CONTROLLER_MANAGER_API_PORT:=8081}
               protocol: TCP
           env:
             - name: API_ENDPOINT
@@ -79,4 +79,14 @@ spec:
             requests:
               cpu: 100m
               memory: 128Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
       terminationGracePeriodSeconds: 10

--- a/app/sidero-controller-manager/internal/healthz/healthz.go
+++ b/app/sidero-controller-manager/internal/healthz/healthz.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package healthz
+
+import (
+	"net/http"
+)
+
+func RegisterServer(mux *http.ServeMux) error {
+	mux.HandleFunc("/healthz", healthzHandler)
+
+	return nil
+}
+
+func healthzHandler(w http.ResponseWriter, req *http.Request) {
+	// do nothing, consider to be healthy always
+}


### PR DESCRIPTION
Fixes #560

The way it was implemented before this change, `errgoup` waits for all
goroutines to finish before it returns, so if the controller crashes due
to election issues, container still keeps running as HTTP API is up.

After this change, container crashes on first error.

Also added liveness/readiness check, they won't help much this issue,
but provide additional layer of protection/visibility.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>