### PR TITLE
chore: fix docker version in the drone pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -188,7 +188,7 @@ steps:
 
 services:
   - name: docker
-    image: docker:19.03-dind
+    image: docker:20.10-dind
     entrypoint:
     - dockerd
     commands:


### PR DESCRIPTION
We need 20+ to get cgroupsv2 compatibility.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>