### PR TITLE
fix: update extension for controlplane.yaml 

### DIFF
--- a/website/content/docs/v0.4/Guides/sidero-on-rpi4.md
+++ b/website/content/docs/v0.4/Guides/sidero-on-rpi4.md
@@ -36,7 +36,7 @@ talosctl gen config --config-patch='[{"op": "add", "path": "/cluster/allowSchedu
 Submit the generated configuration to Talos:
 
 ```bash
-talosctl apply-config --insecure -n ${SIDERO_ENDPOINT} -f controlplane.yml
+talosctl apply-config --insecure -n ${SIDERO_ENDPOINT} -f controlplane.yaml
 ```
 
 Merge client configuration `talosconfig` into default `~/.talos/config` location:


### PR DESCRIPTION
talosctl generates YAML files with the .yaml extension, update to the apply-config command to reflect this

Signed-off-by: Charlie Haley <charlie.haley@hotmail.com>