### PR TITLE
feat: automatically append talos.config to the Environment

### DIFF
--- a/app/sidero-controller-manager/api/v1alpha1/environment_types.go
+++ b/app/sidero-controller-manager/api/v1alpha1/environment_types.go
@@ -78,7 +78,6 @@ func EnvironmentDefaultSpec(talosRelease, apiEndpoint string, apiPort uint16) *E
 	args = append(args, kernel.DefaultArgs...)
 	args = append(args, "console=tty0", "console=ttyS0", "earlyprintk=ttyS0")
 	args = append(args, "initrd=initramfs.xz", "talos.platform=metal")
-	args = append(args, fmt.Sprintf("talos.config=http://%s:%d/configdata?uuid=", apiEndpoint, apiPort))
 	sort.Strings(args)
 
 	return &EnvironmentSpec{

--- a/sfyra/pkg/tests/environment.go
+++ b/sfyra/pkg/tests/environment.go
@@ -6,7 +6,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -91,7 +90,6 @@ func TestEnvironmentCreate(ctx context.Context, metalClient client.Client, clust
 			cmdline.Append("panic", "1")
 			cmdline.Append("talos.platform", "metal")
 			cmdline.Append("talos.shutdown", "halt")
-			cmdline.Append("talos.config", fmt.Sprintf("http://%s:8081/configdata?uuid=", cluster.SideroComponentsIP()))
 			cmdline.Append("initrd", "initramfs.xz")
 
 			environment.APIVersion = constants.SideroAPIVersion

--- a/website/content/docs/v0.5/Guides/first-cluster.md
+++ b/website/content/docs/v0.5/Guides/first-cluster.md
@@ -28,8 +28,16 @@ kubectl patch deploy -n sidero-system sidero-controller-manager --type='json' -p
 
 #### Update Environment
 
-The metadata server's information needs to be updated in the default environment.
-Edit the environment with `kubectl edit environment default` and update the `talos.config` kernel arg with the IP of one of the management plane nodes (or the DNS entry you created).
+The metadata server's information might need to be updated in the default environment.
+
+<!-- textlint-disable -->
+
+Sidero by default appends `talos.config` kernel argument with based on the flags `--api-endpoint` and `--api-port` to the `sidero-controller-manager`:
+`talos.config=http://$API_ENDPOINT:$API_PORT/configdata?uuid=`.
+
+<!-- textlint-enable -->
+
+If this default value doesn't apply, edit the environment with `kubectl edit environment default` and add the `talos.config` kernel arg with the IP of one of the management plane nodes (or the DNS entry you created).
 
 ### Update DHCP
 

--- a/website/content/docs/v0.5/Resource Configuration/environments.md
+++ b/website/content/docs/v0.5/Resource Configuration/environments.md
@@ -43,7 +43,6 @@ spec:
       - pti=on
       - random.trust_cpu=on
       - slab_nomerge=
-      - talos.config=http://$PUBLIC_IP:8081/configdata?uuid=
       - talos.platform=metal
   initrd:
     url: "https://github.com/talos-systems/talos/releases/download/v0.13.0/initramfs-amd64.xz"


### PR DESCRIPTION
Fixes #460

With this change, it's no longer necessary to supply `talos.config` in
the Environment - it is appended dynamically during the boot process.

So `talos.config` is removed even from the default Environment, as this
makes it update automatically if Sidero endpoint gets changed.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>