### PR TITLE
fix: update CAPI resources versions to v1alpha4 in the cluster template

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -69,7 +69,7 @@ spec:
       generateType: join
       talosVersion: ${TALOS_VERSION}
 ---
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-workers


### PR DESCRIPTION
It worked before as it was being migrated from `v1alpha3` to `v1alpha4` when applied.

Fixes: https://github.com/talos-systems/sidero/issues/628

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>