### PR TITLE
fix: make iPXE script replace script on chain request

### DIFF
--- a/app/sidero-controller-manager/internal/ipxe/ipxe_server.go
+++ b/app/sidero-controller-manager/internal/ipxe/ipxe_server.go
@@ -69,7 +69,7 @@ set x:int32 0
 		# attempt boot, if fails try next iface
 		route
 
-		chain http://{{ .Endpoint }}:{{ .Port }}/ipxe?uuid=${uuid}&mac=${net${idx}/mac:hexhyp}&domain=${domain}&hostname=${hostname}&serial=${serial}&arch=${buildarch} || goto next_iface
+		chain --replace http://{{ .Endpoint }}:{{ .Port }}/ipxe?uuid=${uuid}&mac=${net${idx}/mac:hexhyp}&domain=${domain}&hostname=${hostname}&serial=${serial}&arch=${buildarch} || goto next_iface
 
 :exhausted
 	echo


### PR DESCRIPTION
Without `--replace`, if the iPXE script downloaded exists, control goes
back to the main script which will keep retrying. This breaks cases like
`ipxe-exit` which rely on iPXE exit to continue e.g. booting from disk.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>