### PR TITLE
feat: set server PXEBooted condition only after Talos gets installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ MODULE := $(shell head -1 go.mod | cut -d' ' -f2)
 ARTIFACTS := _out
 TEST_PKGS ?= ./...
 TALOS_RELEASE ?= v0.14.0-alpha.2
+PREVIOUS_TALOS_RELEASE ?= v0.13.4
 DEFAULT_K8S_VERSION ?= v1.22.3
 
 TOOLS ?= ghcr.io/talos-systems/tools:v0.9.0
@@ -171,6 +172,7 @@ run-sfyra: talos-artifacts clusterctl-release ## Run Sfyra integration test.
 	@ARTIFACTS=$(ARTIFACTS) \
 		CLUSTERCTL_CONFIG=$(SFYRA_CLUSTERCTL_CONFIG) \
 		TALOS_RELEASE=$(TALOS_RELEASE) \
+		PREVIOUS_TALOS_RELEASE=$(PREVIOUS_TALOS_RELEASE) \
 		./hack/scripts/integration-test.sh
 
 # Development

--- a/app/caps-controller-manager/api/v1alpha3/metalmachine_conditions.go
+++ b/app/caps-controller-manager/api/v1alpha3/metalmachine_conditions.go
@@ -41,6 +41,9 @@ const (
 	// TalosInstalledCondition reports when Talos OS was successfully installed on the node.
 	TalosInstalledCondition clusterv1.ConditionType = "TalosInstalled"
 
+	// TalosInstallationInProgressReason (Severity=Info) documents that Talos installation is in progress.
+	TalosInstallationInProgressReason = "TalosInstallationInProgress"
+
 	// TalosInstallationFailedReason (Severity=Error) documents that Talos installer has failed.
 	TalosInstallationFailedReason = "TalosInstallationFailed"
 )

--- a/app/sidero-controller-manager/internal/ipxe/ipxe_server.go
+++ b/app/sidero-controller-manager/internal/ipxe/ipxe_server.go
@@ -220,7 +220,15 @@ func ipxeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// This code is left here only for backward compatibility with Talos <= v0.13.
 	if !strings.HasPrefix(env.ObjectMeta.Name, "agent") {
+		// Do not mark as PXE booted here if SideroLink events are available and Talos installation is in progress.
+		// SideroLink events handler will mark the machine with TalosInstalledCondition condition,
+		// then server controller will reconcile this status and mark server as PXEBooted.
+		if conditions.Has(serverBinding, infrav1.TalosInstalledCondition) {
+			return
+		}
+
 		if err = markAsPXEBooted(server); err != nil {
 			log.Printf("error marking server as PXE booted: %s", err)
 		}

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -66,3 +66,9 @@ fails on the node.
 - `TalosInstalled` is set to true/false when talos installer finishes.
 """
 
+    [notes.pxeboot]
+        title = "Retry PXE Boot"
+        description = """\
+Sidero server controller now keeps track of Talos installation progress.
+Now the node will be PXE booted until Talos installation succeeds.
+"""

--- a/hack/scripts/integration-test.sh
+++ b/hack/scripts/integration-test.sh
@@ -36,9 +36,15 @@ else
     PREFIX=
 fi
 
+COMPATIBILITY_TESTS_ARGS=
+
+if [[ ! -z "${PREVIOUS_TALOS_RELEASE}" ]]; then
+    COMPATIBILITY_TESTS_ARGS="--prev-talos-release=${PREVIOUS_TALOS_RELEASE}"
+fi
+
 ${PREFIX} "${INTEGRATION_TEST}" test integration \
     --talosctl-path "${TALOSCTL}" \
     --clusterctl-config "${CLUSTERCTL_CONFIG}" \
     --power-simulated-explicit-failure-prob=0.1 \
     --power-simulated-silent-failure-prob=0.0 \
-    ${REGISTRY_MIRROR_FLAGS} ${SFYRA_EXTRA_FLAGS}
+    ${COMPATIBILITY_TESTS_ARGS} ${REGISTRY_MIRROR_FLAGS} ${SFYRA_EXTRA_FLAGS}

--- a/sfyra/cmd/sfyra/cmd/options.go
+++ b/sfyra/cmd/sfyra/cmd/options.go
@@ -42,7 +42,8 @@ type Options struct {
 
 	DefaultBootOrder string
 
-	TalosctlPath string
+	TalosctlPath     string
+	PrevTalosRelease string
 
 	PowerSimulatedExplicitFailureProb float64
 	PowerSimulatedSilentFailureProb   float64

--- a/sfyra/cmd/sfyra/cmd/test_integration.go
+++ b/sfyra/cmd/sfyra/cmd/test_integration.go
@@ -112,6 +112,7 @@ var testIntegrationCmd = &cobra.Command{
 				RunTestPattern: runTestPattern,
 
 				TalosRelease:      TalosRelease,
+				PrevTalosRelease:  options.PrevTalosRelease,
 				KubernetesVersion: KubernetesVersion,
 			}); !ok {
 				return fmt.Errorf("test failure")
@@ -144,4 +145,5 @@ func init() {
 	testIntegrationCmd.Flags().Float64Var(&options.PowerSimulatedExplicitFailureProb, "power-simulated-explicit-failure-prob", options.PowerSimulatedExplicitFailureProb, "simulated power management explicit failure probability")
 	testIntegrationCmd.Flags().Float64Var(&options.PowerSimulatedSilentFailureProb, "power-simulated-silent-failure-prob", options.PowerSimulatedSilentFailureProb, "simulated power management silent failure probability")
 	testIntegrationCmd.Flags().StringVar(&runTestPattern, "test.run", "", "tests to run (regular expression)")
+	testIntegrationCmd.Flags().StringVar(&options.PrevTalosRelease, "prev-talos-release", options.PrevTalosRelease, "Talos version to run compatibility tests against")
 }

--- a/sfyra/pkg/tests/compatibility.go
+++ b/sfyra/pkg/tests/compatibility.go
@@ -1,0 +1,113 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stretchr/testify/require"
+	"github.com/talos-systems/go-procfs/procfs"
+	"github.com/talos-systems/go-retry/retry"
+	"github.com/talos-systems/talos/pkg/machinery/kernel"
+
+	"github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	"github.com/talos-systems/sidero/sfyra/pkg/capi"
+	"github.com/talos-systems/sidero/sfyra/pkg/constants"
+	"github.com/talos-systems/sidero/sfyra/pkg/talos"
+	"github.com/talos-systems/sidero/sfyra/pkg/vm"
+)
+
+const (
+	compatibilityClusterName   = "compatibility-cluster"
+	compatibilityClusterLBPort = 10003
+)
+
+// TestCompatibilityCluster deploys the compatibility cluster via CAPI.
+func TestCompatibilityCluster(ctx context.Context, metalClient client.Client, cluster talos.Cluster, vmSet *vm.Set, capiManager *capi.Manager, talosRelease, kubernetesVersion string) TestFunc {
+	return func(t *testing.T) {
+		if talosRelease == "" {
+			t.Skip("--prev-talos-release is not set, skipped compatibility check")
+		}
+
+		var environment v1alpha1.Environment
+
+		envName := fmt.Sprintf("talos-%s", strings.ReplaceAll(talosRelease, ".", "-"))
+
+		if err := metalClient.Get(ctx, types.NamespacedName{Name: envName}, &environment); err != nil {
+			if !apierrors.IsNotFound(err) {
+				require.NoError(t, err)
+			}
+
+			cmdline := procfs.NewCmdline("")
+			cmdline.SetAll(kernel.DefaultArgs)
+
+			cmdline.Append("console", "ttyS0")
+			cmdline.Append("talos.platform", "metal")
+
+			environment.APIVersion = constants.SideroAPIVersion
+			environment.Name = envName
+			environment.Spec.Kernel.URL = fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/vmlinuz-amd64", talosRelease)
+			environment.Spec.Kernel.SHA512 = ""
+			environment.Spec.Kernel.Args = cmdline.Strings()
+			environment.Spec.Initrd.URL = fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/initramfs-amd64.xz", talosRelease)
+			environment.Spec.Initrd.SHA512 = ""
+
+			require.NoError(t, metalClient.Create(ctx, &environment))
+		}
+
+		// wait for the environment to report ready
+		require.NoError(t, retry.Constant(5*time.Minute, retry.WithUnits(10*time.Second)).Retry(func() error {
+			if err := metalClient.Get(ctx, types.NamespacedName{Name: envName}, &environment); err != nil {
+				return err
+			}
+
+			if !isEnvironmentReady(&environment) {
+				return retry.ExpectedErrorf("some assets are not ready")
+			}
+
+			return nil
+		}))
+
+		serverClassName := envName
+		classSpec := v1alpha1.ServerClassSpec{
+			Qualifiers: v1alpha1.Qualifiers{
+				CPU: []v1alpha1.CPUInformation{
+					{
+						Manufacturer: "QEMU",
+					},
+				},
+			},
+			EnvironmentRef: &v1.ObjectReference{
+				Name: envName,
+			},
+		}
+
+		_, err := createServerClass(ctx, metalClient, serverClassName, classSpec)
+		require.NoError(t, err)
+
+		ex, err := os.Executable()
+		require.NoError(t, err)
+
+		exPath := filepath.Dir(ex)
+
+		loadbalancer := deployCluster(ctx, t, metalClient, cluster, vmSet, capiManager, compatibilityClusterName, serverClassName, compatibilityClusterLBPort, 1, 0, talosRelease, kubernetesVersion,
+			withConfigURL(fmt.Sprintf("file://%s/../templates/cluster-template-talos-%s.yaml", exPath, talosRelease)),
+		)
+
+		deleteCluster(ctx, t, metalClient, compatibilityClusterName)
+		loadbalancer.Close() //nolint:errcheck
+	}
+}

--- a/sfyra/pkg/tests/tests.go
+++ b/sfyra/pkg/tests/tests.go
@@ -28,6 +28,7 @@ type Options struct {
 	RunTestPattern string
 
 	TalosRelease      string
+	PrevTalosRelease  string
 	KubernetesVersion string
 }
 
@@ -92,6 +93,14 @@ func Run(ctx context.Context, cluster talos.Cluster, vmSet *vm.Set, capiManager 
 		{
 			"TestServerClassPatch",
 			TestServerClassPatch(ctx, metalClient, cluster, capiManager),
+		},
+		{
+			"TestCompatibilityCluster",
+			TestCompatibilityCluster(ctx, metalClient, cluster, vmSet, capiManager, options.PrevTalosRelease, options.KubernetesVersion),
+		},
+		{
+			"TestServerPXEBoot",
+			TestServerPXEBoot(ctx, metalClient, cluster, vmSet, capiManager, options.TalosRelease, options.KubernetesVersion),
 		},
 		{
 			"TestManagementCluster",

--- a/sfyra/pkg/tests/workload_cluster.go
+++ b/sfyra/pkg/tests/workload_cluster.go
@@ -23,7 +23,7 @@ const (
 // TestWorkloadCluster deploys and destroys the workload cluster via CAPI.
 func TestWorkloadCluster(ctx context.Context, metalClient client.Client, cluster talos.Cluster, vmSet *vm.Set, capiManager *capi.Manager, talosRelease, kubernetesVersion string) TestFunc {
 	return func(t *testing.T) {
-		loadbalancer, _ := deployCluster(ctx, t, metalClient, cluster, vmSet, capiManager, workloadClusterName, serverClassName, workloadClusterLBPort, 1, 0, talosRelease, kubernetesVersion)
+		loadbalancer := deployCluster(ctx, t, metalClient, cluster, vmSet, capiManager, workloadClusterName, serverClassName, workloadClusterLBPort, 1, 0, talosRelease, kubernetesVersion)
 		defer loadbalancer.Close()
 
 		deleteCluster(ctx, t, metalClient, workloadClusterName)

--- a/templates/cluster-template-talos-v0.13.4.yaml
+++ b/templates/cluster-template-talos-v0.13.4.yaml
@@ -1,0 +1,107 @@
+# this is cluster template for Talos <= v0.13
+# which is used to test backward compatibility
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 10.244.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: MetalCluster
+    name: ${CLUSTER_NAME}
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    kind: TalosControlPlane
+    name: ${CLUSTER_NAME}-cp
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: MetalCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  controlPlaneEndpoint:
+    host: ${CONTROL_PLANE_ENDPOINT}
+    port: ${CONTROL_PLANE_PORT}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: MetalMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-cp
+spec:
+  template:
+    spec:
+      serverClassRef:
+        apiVersion: metal.sidero.dev/v1alpha1
+        kind: ServerClass
+        name: ${CONTROL_PLANE_SERVERCLASS}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: TalosControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-cp
+spec:
+  version: ${KUBERNETES_VERSION}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  infrastructureTemplate:
+    kind: MetalMachineTemplate
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    name: ${CLUSTER_NAME}-cp
+  controlPlaneConfig:
+    init:
+      generateType: init
+      talosVersion: ${TALOS_VERSION}
+    controlplane:
+      generateType: controlplane
+      talosVersion: ${TALOS_VERSION}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+kind: TalosConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+spec:
+  template:
+    spec:
+      generateType: join
+      talosVersion: ${TALOS_VERSION}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-workers
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      version: ${KUBERNETES_VERSION}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: TalosConfigTemplate
+          name: ${CLUSTER_NAME}-workers
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: MetalMachineTemplate
+        name: ${CLUSTER_NAME}-workers
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: MetalMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+spec:
+  template:
+    spec:
+      serverClassRef:
+        apiVersion: metal.sidero.dev/v1alpha1
+        kind: ServerClass
+        name: ${WORKER_SERVERCLASS}


### PR DESCRIPTION
Now `PXEBooted` condition is derived from `TalosInstalled` condition of
the linked `ServerBinding`.
This makes the node to use `pxe` boot until Talos installation succeeds.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>